### PR TITLE
Simplifying and making the os tag stringification maintainable

### DIFF
--- a/src/cli/cli.zig
+++ b/src/cli/cli.zig
@@ -1,6 +1,4 @@
 pub const install = @import("install.zig");
-pub const system = @import("system.zig");
-pub const use = @import("use.zig");
 const std = @import("std");
 const mem = std.mem;
 const testing = std.testing;
@@ -14,7 +12,7 @@ pub const Args = struct {
     /// `parse()` analyzes command line arguments and fill the appropriate struct fields.
     ///
     /// If arguments for 'help' or 'version' are detected. `parse()` will print
-    /// the appropiate value to stderr and exit 0.
+    /// the appropriate value to stderr and exit 0.
     pub fn parse(self: *Args, alloc: std.mem.Allocator) !void {
         const args: [][:0]u8 = try std.process.argsAlloc(alloc);
         if (args.len > 0) self.positionals = args else return;

--- a/src/cli/system.zig
+++ b/src/cli/system.zig
@@ -81,6 +81,7 @@ test "string returned by the conversion to string of the tag" {
         .other => "other",
         .freestanding => "freestanding",
     };
-    const new_tag = try getSystemInfo().tag;
+    const new_func = try getSystemInfo();
+    const new_tag = new_func.tag;
     try std.testing.expectEqualStrings(old_tag, new_tag);
 }

--- a/src/cli/system.zig
+++ b/src/cli/system.zig
@@ -9,13 +9,13 @@ pub fn homeDir(alloc: std.mem.Allocator) ?[]u8 {
     return std.process.getEnvVarOwned(alloc, "HOME") catch null;
 }
 
-fn getSystemInfo() !SystemInfo {
+pub fn getSystemInfo() !SystemInfo {
     const info = try NativeTargetInfo.detect(.{});
     const arch = info.target.cpu.arch.genericName();
     // https://discord.com/channels/605571803288698900/1019652020308824145
     // A switch with an inline else can be used to make special cases for some
     // tags.
-    const tag = @tagName(enum_tag);
+    const tag = @tagName(info.target.os.tag);
     return SystemInfo{ .arch = arch, .tag = @as([]const u8, tag) };
 }
 

--- a/src/curl.zig
+++ b/src/curl.zig
@@ -45,7 +45,7 @@ fn writeToArrayListCallback(data: *anyopaque, size: c_uint, nmemb: c_uint, user_
     return nmemb * size;
 }
 
-/// parseVersionJSON takes the resturned result from fetchVersionJSON and parses it into a std.json.ValueTree.
+/// parseVersionJSON takes the returned result from fetchVersionJSON and parses it into a std.json.ValueTree.
 pub fn parseVersionJSON(json: *std.ArrayList(u8), alloc: *std.mem.Allocator) !std.json.ValueTree {
     // std.debug.print("{s}", .{json.items});
     var parser = std.json.Parser.init(alloc.*, false);
@@ -94,4 +94,3 @@ pub fn downloadFile(url: [:0]const u8, path: []const u8) !void {
         return CurlError.FailedToPerformRequest;
     }
 }
-

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,7 +7,7 @@ const builtin = @import("builtin");
 
 pub fn main() !void {
 
-    // Fetching data. Where we currenlty process the cli.
+    // Fetching data. Where we currently process the cli.
 
     // FETCHING DATA
     var arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
@@ -36,4 +36,3 @@ pub fn main() !void {
         }
     }
 }
-


### PR DESCRIPTION
This commit contains some grammar checks (sorry for not squashing the commit, I wanted to keep those modifications separate), and replaces the exhaustive switch on the OS tag with a compile-time stringification of the enum (the value is replaced by its name, as it seemed intended).
I couldn't read the discord message that was linked in the comment, as it has likely been made unreachable by the conversion of the channel to a forum, I don't know if it needs to be removed.

Thanks for your hard work !