### PR TITLE
install: Fix darwin system info

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -133,15 +133,20 @@ func getTarPath(version string, data *map[string]map[string]any) (*string, error
 }
 
 func zigStyleSysInfo() (string, string) {
-	var arch string
-	switch runtime.GOARCH {
+    arch := runtime.GOARCH
+    goos := runtime.GOOS
+
+	switch arch {
 	case "amd64":
 		arch = "x86_64"
-	default:
-		arch = runtime.GOARCH
 	}
 
-	return arch, runtime.GOOS
+    switch goos {
+    case "darwin":
+        goos = "macos"
+    }
+
+	return arch, goos
 }
 
 func extractTarXZ(bundle, out string) error {


### PR DESCRIPTION
The `zigStyleSysInfo` function returns `*-darwin` for MacOS machines. However, the data at https://ziglang.org/download/index.json does not have any `*-darwin` versions, it only has `*-macos` versions.

This PR converts any `darwin` OS values returned by `zigStyleSysInfo` to `macos`.