### PR TITLE
Fix error handling in ZVM.Use.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "deno.enable": true,
-    "deno.unstable": true
+  "deno.enable": true,
+  "deno.unstable": true
 }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 ## Join our Community
+
 - [Discord](https://discord.gg/NhaNhCMYX8)
 - [Twitch](https://twitch.tv/atalocke)
 
@@ -25,6 +26,7 @@ If you're on Windows, please grab the
 [latest release](https://github.com/tristanisham/zvm/releases/latest).
 
 ## Community Package
+
 ### AUR
 
 `zvm` on the [Arch AUR](https://aur.archlinux.org/packages/zvm) is a community

--- a/build.ts
+++ b/build.ts
@@ -2,82 +2,88 @@
 import { Tar } from "https://deno.land/std@0.184.0/archive/mod.ts";
 import { copy } from "https://deno.land/std@0.184.0/streams/copy.ts";
 
-
-
-
 const GOARCH = [
-    "amd64", "arm64"
+  "amd64",
+  "arm64",
 ];
 
 const GOOS = [
-    "windows", "linux", "darwin", "freebsd", "netbsd",
-    "openbsd",
-    "plan9",
-    "solaris",
-]
+  "windows",
+  "linux",
+  "darwin",
+  "freebsd",
+  "netbsd",
+  "openbsd",
+  "plan9",
+  "solaris",
+];
 
-await Deno.mkdir("./build", {recursive: true});
+await Deno.mkdir("./build", { recursive: true });
 
-console.time("Built zvm")
-
+console.time("Built zvm");
 
 for (const os of GOOS) {
-    for (const ar of GOARCH) {
-        if (os == "solaris" && ar == "arm64" || os == "plan9" && ar == "arm64") continue;
-        Deno.env.set("GOOS", os)
-        Deno.env.set("GOARCH", ar)
-        // Deno.env.set("CGO_ENABLED", "1")
-        const zvm_str = `zvm-${os}-${ar}`
-        console.time(`Build zvm: ${zvm_str}`)
-        const build_cmd = Deno.run({
-            cmd: [
-                "go",
-                "build",
-                "-o",
-                `build/${zvm_str}/zvm${(os == "windows" ? ".exe" : "")}`,
-                '-ldflags=-s -w',
-            ],
-        });
-
-        const {code} = await build_cmd.status();
-        if (code !== 0) {
-            console.error("Something went wrong")
-            Deno.exit(1);
-        }
-        
-        console.timeEnd(`Build zvm: ${zvm_str}`)
+  for (const ar of GOARCH) {
+    if (os == "solaris" && ar == "arm64" || os == "plan9" && ar == "arm64") {
+      continue;
     }
+    Deno.env.set("GOOS", os);
+    Deno.env.set("GOARCH", ar);
+    // Deno.env.set("CGO_ENABLED", "1")
+    const zvm_str = `zvm-${os}-${ar}`;
+    console.time(`Build zvm: ${zvm_str}`);
+    const build_cmd = Deno.run({
+      cmd: [
+        "go",
+        "build",
+        "-o",
+        `build/${zvm_str}/zvm${(os == "windows" ? ".exe" : "")}`,
+        "-ldflags=-s -w",
+      ],
+    });
+
+    const { code } = await build_cmd.status();
+    if (code !== 0) {
+      console.error("Something went wrong");
+      Deno.exit(1);
+    }
+
+    console.timeEnd(`Build zvm: ${zvm_str}`);
+  }
 }
 
-Deno.chdir("build")
+Deno.chdir("build");
 for (const os of GOOS) {
-    for (const ar of GOARCH) {
-        if (os == "solaris" && ar == "arm64" || os == "plan9" && ar == "arm64") continue;
-        const zvm_str = `zvm-${os}-${ar}`
-
-        if (os == "windows") {
-            console.time(`Compress zvm: ${zvm_str}`)
-            const zip = new Deno.Command(`zip`, {
-                args: [`${zvm_str}.zip`, `${zvm_str}/zvm.exe`],
-                stdin: "piped",
-                stdout: "piped",
-            });
-            zip.spawn();
-            console.timeEnd(`Compress zvm: ${zvm_str}`)
-            continue;
-        }
-        const tar = new Tar()
-        console.time(`Compress zvm: ${zvm_str}`)
-        await tar.append("zvm", {
-            filePath: `${zvm_str}/zvm`
-        })
-        const writer = await Deno.open(`./${zvm_str}.tar`, { write: true, create: true })
-        await copy(tar.getReader(), writer);
-        writer.close();
-        console.timeEnd(`Compress zvm: ${zvm_str}`)
-
+  for (const ar of GOARCH) {
+    if (os == "solaris" && ar == "arm64" || os == "plan9" && ar == "arm64") {
+      continue;
     }
+    const zvm_str = `zvm-${os}-${ar}`;
+
+    if (os == "windows") {
+      console.time(`Compress zvm: ${zvm_str}`);
+      const zip = new Deno.Command(`zip`, {
+        args: [`${zvm_str}.zip`, `${zvm_str}/zvm.exe`],
+        stdin: "piped",
+        stdout: "piped",
+      });
+      zip.spawn();
+      console.timeEnd(`Compress zvm: ${zvm_str}`);
+      continue;
+    }
+    const tar = new Tar();
+    console.time(`Compress zvm: ${zvm_str}`);
+    await tar.append("zvm", {
+      filePath: `${zvm_str}/zvm`,
+    });
+    const writer = await Deno.open(`./${zvm_str}.tar`, {
+      write: true,
+      create: true,
+    });
+    await copy(tar.getReader(), writer);
+    writer.close();
+    console.timeEnd(`Compress zvm: ${zvm_str}`);
+  }
 }
 
-console.timeEnd(`Built zvm`)
-
+console.timeEnd(`Built zvm`);

--- a/cli/config.go
+++ b/cli/config.go
@@ -48,9 +48,9 @@ func Initialize() *ZVM {
 }
 
 type ZVM struct {
-	zvmBaseDir     string
-	zigVersions    zigVersionMap
-	Settings       Settings
+	zvmBaseDir  string
+	zigVersions zigVersionMap
+	Settings    Settings
 }
 
 // A representaiton of the offical json schema for Zig versions

--- a/cli/config.go
+++ b/cli/config.go
@@ -79,16 +79,16 @@ func (z *ZVM) loadVersionCache() error {
 	return nil
 }
 
-func (z ZVM) getVersion(version string) *zigVersion {
-	if _, err := os.Stat(filepath.Join(z.zvmBaseDir, version)); errors.Is(err, os.ErrNotExist) {
-		return nil
+func (z ZVM) getVersion(version string) (zigVersion, error) {
+	if _, err := os.Stat(filepath.Join(z.zvmBaseDir, version)); err != nil {
+		return nil, err
 	}
 
 	if version, ok := z.zigVersions[version]; ok {
-		return &version
+		return version, nil
+	} else {
+		return nil, fmt.Errorf("version %s is not a released version", version)
 	}
-
-	return nil
 }
 
 func (z *ZVM) loadSettings() error {

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -2,11 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"github.com/charmbracelet/log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"github.com/charmbracelet/log"
 
 	"github.com/tristanisham/clr"
 )

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -12,7 +12,6 @@ import (
 type Settings struct {
 	basePath string
 	UseColor bool `json:"useColor"`
-
 }
 
 func (s *Settings) ToggleColor() {
@@ -25,7 +24,7 @@ func (s *Settings) ToggleColor() {
 		fmt.Printf("Terminal color output: %s\n", clr.Green("ON"))
 		return
 	}
-	
+
 	fmt.Println("Terminal color output: OFF")
 
 }
@@ -47,8 +46,6 @@ func (s *Settings) YesColor() {
 	fmt.Printf("Terminal color output: %s\n", clr.Green("ON"))
 
 }
-
-
 
 func (s Settings) save() error {
 	out_settings, err := json.MarshalIndent(&s, "", "    ")

--- a/cli/use.go
+++ b/cli/use.go
@@ -21,7 +21,6 @@ func (z *ZVM) Use(ver string) error {
 		}
 	}
 
-	
 	return z.setBin(ver)
 }
 
@@ -34,7 +33,6 @@ func (z *ZVM) setBin(ver string) error {
 	if err := os.Symlink(version_path, filepath.Join(z.zvmBaseDir, "bin")); err != nil {
 		return err
 	}
-	
 
 	return nil
 }

--- a/cli/use.go
+++ b/cli/use.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,13 +13,18 @@ import (
 
 func (z *ZVM) Use(ver string) error {
 	z.loadVersionCache()
-	if verMapPtr := z.getVersion(ver); verMapPtr == nil {
+	_, err := z.getVersion(ver)
+	if errors.Is(err, os.ErrNotExist) {
 		fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", ver)
 		if getConfirmation() {
-			return z.Install(ver)
+			err = z.Install(ver)
 		} else {
-			os.Exit(0)
+			return fmt.Errorf("version %s is not installed", ver)
 		}
+	}
+
+	if err != nil {
+		return err
 	}
 
 	return z.setBin(ver)

--- a/cli/version.go
+++ b/cli/version.go
@@ -17,7 +17,7 @@ func (z *ZVM) fetchVersionMap() (zigVersionMap, error) {
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", "zvm (Zig Version Manager) " + VERSION)
+	req.Header.Set("User-Agent", "zvm (Zig Version Manager) "+VERSION)
 	client := http.DefaultClient
 	resp, err := client.Do(req)
 	if err != nil {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
-    "tasks": {
-        "build": "deno run -A build.ts",
-        "clean": "rm -r build"
-    }
+  "tasks": {
+    "build": "deno run -A build.ts",
+    "clean": "rm -r build"
+  }
 }


### PR DESCRIPTION
I removed an useless os.Exit call and made the error handling a bit cleaner.

If the user decides to install version upon calling use, and the installation fails, the user now gets informed