### PR TITLE
Option to Install ZLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ zvm i <version> [-z]
 
 Use `install` or `i` to download a specific version of Zig. To install the
 latest version, use "master". Optionally, the `--zls` or `-z` flag can be added to 
-install Zig Language Server (ZLS) as well.
+install Zig Language Server (ZLS) as well. If you intend to install a fixed
+release of ZLS, you may need to also install [zstd](https://github.com/facebook/zstd/releases),
+which is available through the package manager for your system or on GitHub.
 
 ```sh
 # Example

--- a/README.md
+++ b/README.md
@@ -99,13 +99,14 @@ like to suggest
 ## Install
 
 ```sh
-zvm install <version>
+zvm install <version> [--zls]
 # Or
-zvm i <version>
+zvm i <version> [-z]
 ```
 
 Use `install` or `i` to download a specific version of Zig. To install the
-latest version, use "master".
+latest version, use "master". Optionally, the `--zls` or `-z` flag can be added to 
+install Zig Language Server (ZLS) as well.
 
 ```sh
 # Example

--- a/cli/install.go
+++ b/cli/install.go
@@ -229,6 +229,8 @@ func (z *ZVM) InstallZls(version string) error {
 
 	}
 
+	z.createSymlink(version)
+
 	fmt.Println("Copy complete")
 	return nil
 }

--- a/cli/install.go
+++ b/cli/install.go
@@ -420,11 +420,18 @@ func zigStyleSysInfo() (arch string, os string) {
 }
 
 func ExtractBundle(bundle, out string) error {
-	if runtime.GOOS == "windows" {
+	// get extension
+	replacedBundle := strings.ReplaceAll(bundle, "\\", "/")
+	splitPath := strings.Split(replacedBundle, "/")
+	_, extension, _ := strings.Cut(splitPath[len(splitPath)-1], ".")
+
+	if strings.Contains(extension, "tar") {
+		return untarXZ(bundle, out)
+	} else if strings.Contains(extension, "zip") {
 		return unzipSource(bundle, out)
 	}
 
-	return untarXZ(bundle, out)
+	return fmt.Errorf("unknown format %v", extension)
 }
 
 func untarXZ(in, out string) error {

--- a/cli/install.go
+++ b/cli/install.go
@@ -264,7 +264,7 @@ func (z *ZVM) InstallZls(version string) error {
 		releaseBuffer.ReadFrom(resp.Body)
 
 		// some github releases use tar.gz, some tar.xz
-		expectedFileNameNoEnding := fmt.Sprintf("zls-%v-%v", arch, osType)
+		expectedArchOs := fmt.Sprintf("%v-%v", arch, osType)
 		zipName := ""
 		var taggedReleaseResponse githubTaggedReleaseResponse
 		// getting list of assets
@@ -275,7 +275,7 @@ func (z *ZVM) InstallZls(version string) error {
 		// getting platform information
 		downloadUrl := ""
 		for _, asset := range taggedReleaseResponse.Assets {
-			if strings.Contains(asset.Name, expectedFileNameNoEnding) {
+			if strings.Contains(asset.Name, expectedArchOs) {
 				downloadUrl = asset.Url
 				zipName = asset.Name
 				break
@@ -284,7 +284,7 @@ func (z *ZVM) InstallZls(version string) error {
 
 		// couldn't find the file
 		if downloadUrl == "" {
-			return fmt.Errorf("could not find %v", expectedFileNameNoEnding)
+			return fmt.Errorf("could not find zls-%v", expectedArchOs)
 		}
 
 		client := &http.Client{}
@@ -323,6 +323,9 @@ func (z *ZVM) InstallZls(version string) error {
 			log.Fatal(err)
 		}
 		if err := os.Rename(filepath.Join(versionPath, "bin", filename), filepath.Join(versionPath, filename)); err != nil {
+			return err
+		}
+		if err := os.Chmod(filepath.Join(versionPath, filename), 0755); err != nil {
 			return err
 		}
 	}

--- a/help.txt
+++ b/help.txt
@@ -2,9 +2,10 @@ zvm (Zig Version Manager) {{.Version}}
 © 2023-present Tristan Isham
 --------------------------------
 
-install, i <version>
+install, i <version> [--zls]
   Use `install` or `i` to download a specific version of Zig.
   To install the latest version, use "master".
+  To install Zig Language server, add the flag --zls or -z
 
 use <version>
   Use `use` to switch between versions of Zig.

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/charmbracelet/log"
 	"html/template"
 	"os"
+	"slices"
 	"strings"
 	"zvm/cli"
 	"zvm/cli/meta"
@@ -35,9 +36,18 @@ func main() {
 	for i, arg := range args {
 		switch arg {
 		case "install", "i":
+			// signal to install zls after zig
+
 			if len(args) > i+1 {
+				install_zls := slices.Contains(args, "--zls") || slices.Contains(args, "-z")
 				version := strings.TrimPrefix(args[i+1], "v")
 				if err := zvm.Install(version); err != nil {
+					log.Fatal(err)
+				}
+				if !install_zls {
+					return
+				}
+				if err := zvm.InstallZls(version); err != nil {
 					log.Fatal(err)
 				}
 			}


### PR DESCRIPTION
Added a flag to install ZLS along with zig, this is useful for users not using vscode who have to install zls manually to have language server functionality in their editor.
Limitations of this change: cannot install ZLS prior to 0.11.0 by default on Windows as it is packaged as a tarball, which can't be untarred by default.

Tested on:
Linux x86_64
Windows x86_64
MacOS aarch64