### PR TITLE
feat: adds a version map url setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,6 @@ Use `clean` to remove build artifacts (Good if you're on Windows).
 
 ```sh
 zvm version
-# Or
-zvm --version
-# Or
-zvm -v
 ```
 
 Prints the version of ZVM you have installed.
@@ -194,10 +190,7 @@ Prints the version of ZVM you have installed.
 
 ```sh
 zvm help
-# Or
-zvm --help
-# Or
-zvm -h
+
 ```
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -208,4 +208,5 @@ zvm -h
 --nocolor, --nocolour   # Turns off ANSI color.
 --color, --colour       # Toggles ANSI color.
 --yescolor, --yescolour # Turns on ANSI color.
+--versionmapurl         # Changes the version map(version history) url
 ```

--- a/cli/error.go
+++ b/cli/error.go
@@ -10,4 +10,5 @@ var (
 	ErrUnsupportedVersion = errors.New("unsupported Zig version")
 	ErrMissingInstallPathEnv = errors.New("env 'ZVM_INSTALL' is not set")
 	ErrFailedUpgrade = errors.New("failed to self-upgrade zvm")
+	ErrInvalidVersionMap = errors.New("invalid version map format")
 )

--- a/cli/install.go
+++ b/cli/install.go
@@ -126,13 +126,12 @@ func (z *ZVM) Install(version string) error {
 	}
 	var tarName string
 
+	resultUrl, err := url.Parse(tarPath)
+	if err != nil {
+		log.Error(err)
+		tarName = version
+	}
 	if wasZigOnl {
-		resultUrl, err := url.Parse(tarPath)
-		if err != nil {
-			log.Error(err)
-			tarName = version
-		}
-
 		if rel := resultUrl.Query().Get("release"); len(rel) > 0 {
 			tarName = strings.Replace(rel, " ", "+", 1)
 		} else {
@@ -140,8 +139,9 @@ func (z *ZVM) Install(version string) error {
 		}
 
 	} else {
-		tarName = strings.TrimPrefix(tarPath, "https://ziglang.org/builds/")
-		tarName = strings.TrimPrefix(tarName, fmt.Sprintf("https://ziglang.org/download/%s/", version))
+		// Maybe think of a better algorithm
+		urlPath := strings.Split(resultUrl.Path, "/")
+		tarName = urlPath[len(urlPath)-1]
 		tarName = strings.TrimSuffix(tarName, ".tar.xz")
 		tarName = strings.TrimSuffix(tarName, ".zip")
 	}

--- a/cli/install.go
+++ b/cli/install.go
@@ -27,8 +27,7 @@ import (
 func (z *ZVM) Install(version string) error {
 
 	os.Mkdir(z.zvmBaseDir, 0755)
-
-	rawVersionStructure, err := z.fetchOfficialVersionMap()
+	rawVersionStructure, err := z.fetchVersionMap()
 	if err != nil {
 		return err
 	}

--- a/cli/install.go
+++ b/cli/install.go
@@ -307,6 +307,10 @@ func (z *ZVM) InstallZls(version string) error {
 	defer tempDir.Close()
 	defer os.RemoveAll(tempDir.Name())
 
+	// if resp.ContentLength == 0 {
+	// 	return fmt.Errorf("invalid ZLS content length (%d bytes)", resp.ContentLength)
+	// }
+
 	pbar := progressbar.DefaultBytes(
 		int64(resp.ContentLength),
 		"Downloading ZLS",

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -53,7 +53,7 @@ func (z *ZVM) ListVersions() error {
 }
 
 func (z ZVM) ListRemoteAvailable() error {
-	versions, err := z.fetchOfficialVersionMap()
+	versions, err := z.fetchVersionMap()
 	if err != nil {
 		return err
 	}

--- a/cli/meta/version.go
+++ b/cli/meta/version.go
@@ -1,4 +1,4 @@
 package meta
 
-const VERSION = "v0.5.0"
+const VERSION = "v0.5.1"
 

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Settings struct {
-	basePath            string
-	UseColor            bool `json:"useColor"`
+	basePath      string
+	UseColor      bool   `json:"useColor"`
+	VersionMapUrl *string `json:"versionMapUrl,omitempty"`
 }
 
 func (s *Settings) ToggleColor() {
@@ -46,7 +47,13 @@ func (s *Settings) YesColor() {
 	fmt.Printf("Terminal color output: %s\n", clr.Green("ON"))
 
 }
-
+func (s *Settings) SetVersionMapUrl(versionMapUrl string) {
+	s.VersionMapUrl = &versionMapUrl
+	if err := s.save(); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Version map url: %s\n", clr.Blue(versionMapUrl))
+}
 func (s Settings) save() error {
 	out_settings, err := json.MarshalIndent(&s, "", "    ")
 	if err != nil {

--- a/cli/version.go
+++ b/cli/version.go
@@ -9,10 +9,15 @@ import (
 	"zvm/cli/meta"
 )
 
+func (z *ZVM) fetchVersionMap() (zigVersionMap, error) {
 
-func (z *ZVM) fetchOfficialVersionMap() (zigVersionMap, error) {
+	defaultVersionMapUrl := "https://ziglang.org/download/index.json"
+	versionMapUrl := z.Settings.VersionMapUrl
+	if versionMapUrl == nil {
+		versionMapUrl = &defaultVersionMapUrl
+	}
 
-	req, err := http.NewRequest("GET", "https://ziglang.org/download/index.json", nil)
+	req, err := http.NewRequest("GET", *versionMapUrl, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/version.go
+++ b/cli/version.go
@@ -13,11 +13,11 @@ func (z *ZVM) fetchVersionMap() (zigVersionMap, error) {
 
 	defaultVersionMapUrl := "https://ziglang.org/download/index.json"
 	versionMapUrl := z.Settings.VersionMapUrl
-	if versionMapUrl == nil {
-		versionMapUrl = &defaultVersionMapUrl
+	if len(versionMapUrl) == 0 {
+		versionMapUrl = defaultVersionMapUrl
 	}
 
-	req, err := http.NewRequest("GET", *versionMapUrl, nil)
+	req, err := http.NewRequest("GET", versionMapUrl, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/help.txt
+++ b/help.txt
@@ -36,4 +36,6 @@ help, --help, -h
 
 --yescolor, --yescolour | Turns on color.
 
+--versionmapurl | Changes the version map(version history) url
+
 Looking for more help? https://github.com/tristanisham/zvm

--- a/help.txt
+++ b/help.txt
@@ -23,10 +23,10 @@ clean
 upgrade 
   Use `upgrade` to update your ZVM install
 
-version, --version, -v
+version
   Prints the version of ZVM you have installed.
 
-help, --help, -h
+help
   Prints this message.
 
 ------------- Flags -----------------

--- a/help.txt
+++ b/help.txt
@@ -36,6 +36,6 @@ help
 
 --yescolor, --yescolour | Turns on color.
 
---versionmapurl | Changes the version map(version history) url
+-vmu | Changes the version map url (Good if you host your own Zig distrobution server)
 
 Looking for more help? https://github.com/tristanisham/zvm

--- a/help.txt
+++ b/help.txt
@@ -31,10 +31,10 @@ help
 
 ------------- Flags -----------------
 
---nocolor, --nocolour | Turns off color.
---color, --colour     | Toggles color.
 
---yescolor, --yescolour | Turns on color.
+--color=<bool> | Turn color printing on or off for ZVM's output
+
+
 
 -vmu | Changes the version map url (Good if you host your own Zig distrobution server)
 

--- a/main.go
+++ b/main.go
@@ -44,13 +44,24 @@ func main() {
 
 	// Global config
 	sVersionMapUrl := flag.String("vmu", "https://ziglang.org/download/index.json", "Set ZVM's version map URL for custom Zig distribution servers")
-
+	sColorToggle := flag.Bool("color", true, "Turn on or off ZVM's color output")
 	flag.Parse()
 
 	if sVersionMapUrl != nil {
 		if err := zvm.Settings.SetVersionMapUrl(*sVersionMapUrl); err != nil {
 			log.Fatal(err)
 		}
+	}
+
+	if sColorToggle != nil {
+		if *sColorToggle != zvm.Settings.UseColor {
+			if *sColorToggle {
+				zvm.Settings.YesColor()
+			} else {
+				zvm.Settings.NoColor()
+			}
+		}
+
 	}
 
 	args = flag.Args()
@@ -155,7 +166,7 @@ func main() {
 		case "--yescolor", "--yescolour":
 			zvm.Settings.YesColor()
 		default:
-			log.Fatalf("invalid argument %q. Please check out help.\n", arg)
+			log.Fatalf("invalid argument %q. Please run `zvm help`.\n", arg)
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Install flags
 	installFlagSet := flag.NewFlagSet("install", flag.ExitOnError)
-    installDeps := installFlagSet.String("D", "", "Specify additional dependencies to install with Zig")
+	installDeps := installFlagSet.String("D", "", "Specify additional dependencies to install with Zig")
 
 	// LS flags
 	lsFlagSet := flag.NewFlagSet("ls", flag.ExitOnError)
@@ -81,7 +81,7 @@ func main() {
 
 		case "ls":
 			lsFlagSet.Parse(args[i+1:])
-			
+
 			if *lsRemote {
 				if err := zvm.ListRemoteAvailable(); err != nil {
 					log.Fatal(err)
@@ -91,7 +91,7 @@ func main() {
 					log.Fatal(err)
 				}
 			}
-			
+
 			return
 		case "uninstall", "rm":
 			if len(args) > i+1 {

--- a/main.go
+++ b/main.go
@@ -42,14 +42,23 @@ func main() {
 	lsFlagSet := flag.NewFlagSet("ls", flag.ExitOnError)
 	lsRemote := lsFlagSet.Bool("all", false, "List all available versions of Zig to install")
 
-	plannedSkips := 0
+	// Global config
+	sVersionMapUrl := flag.String("vmu", "https://ziglang.org/download/index.json", "Set ZVM's version map URL for custom Zig distribution servers")
+
+	flag.Parse()
+
+	if sVersionMapUrl != nil {
+		if err := zvm.Settings.SetVersionMapUrl(*sVersionMapUrl); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	args = flag.Args()
 
 	for i, arg := range args {
-		if plannedSkips > 0 {
-			plannedSkips -= 1
-			continue
-		}
+
 		switch arg {
+
 		case "install", "i":
 			installFlagSet.Parse(args[i+1:])
 			// signal to install zls after zig
@@ -130,10 +139,10 @@ func main() {
 				log.Fatal(err)
 			}
 
-		case "version", "--version", "-v":
+		case "version":
 			fmt.Println(meta.VERSION)
 			return
-		case "help", "--help", "-h":
+		case "help":
 			//zvm.Settings.UseColor
 			helpMsg()
 
@@ -141,21 +150,12 @@ func main() {
 			// Settings
 		case "--nocolor", "--nocolour":
 			zvm.Settings.NoColor()
-		case "--versionmapurl":
-			url := &args[i+1]
-			if url == nil {
-				fmt.Printf("ERROR: Next argument not provided for --versionmapurl. Please check out --help.\n")
-				os.Exit(1)
-			}
-			zvm.Settings.SetVersionMapUrl(*url)
-			plannedSkips = 1
 		case "--color", "--colour":
 			zvm.Settings.ToggleColor()
 		case "--yescolor", "--yescolour":
 			zvm.Settings.YesColor()
 		default:
-			fmt.Printf("ERROR: Invalid argument %s. Please check out --help.\n", arg)
-			os.Exit(1)
+			log.Fatalf("invalid argument %q. Please check out help.\n", arg)
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -42,7 +42,13 @@ func main() {
 	lsFlagSet := flag.NewFlagSet("ls", flag.ExitOnError)
 	lsRemote := lsFlagSet.Bool("all", false, "List all available versions of Zig to install")
 
+	plannedSkips := 0
+
 	for i, arg := range args {
+		if plannedSkips > 0 {
+			plannedSkips -= 1
+			continue
+		}
 		switch arg {
 		case "install", "i":
 			installFlagSet.Parse(args[i+1:])
@@ -135,6 +141,14 @@ func main() {
 			// Settings
 		case "--nocolor", "--nocolour":
 			zvm.Settings.NoColor()
+		case "--versionmapurl":
+			url := &args[i+1]
+			if url == nil {
+				fmt.Printf("ERROR: Next argument not provided for --versionmapurl. Please check out --help.\n")
+				os.Exit(1)
+			}
+			zvm.Settings.SetVersionMapUrl(*url)
+			plannedSkips = 1
 		case "--color", "--colour":
 			zvm.Settings.ToggleColor()
 		case "--yescolor", "--yescolour":


### PR DESCRIPTION
Adds ability to use custom version map url.
## Why implement it?
I need this because many libs use mach version channel and won't compile with the latest.