### PR TITLE
fix: fix installation on aarch64 Linux (#52)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,9 @@ ARCH=$(uname -m)
 OS=$(uname -s)
 
 
+if [ $ARCH = "aarch64" ]; then
+    ARCH="arm64"
+fi
 if [ $ARCH = "x86_64" ]; then
     ARCH="amd64"
 fi


### PR DESCRIPTION
fixes #52 

The command `uname -m` returns `aarch64` on aarch64 Linux, but there is no `zvm-linux-aarch64.tar` on [the release page](https://github.com/tristanisham/zvm/releases/tag/v0.5.5). I've changed `install.sh` so that it treats `aarch64` as `arm64`.

This makes it possible to install zvm on aarch64 Linux. I tested it on my Fedora 39 aarch64 and it worked well.