### PR TITLE
Feat: Windows | Run commands without administrative mode

### DIFF
--- a/bin/elevate.cmd
+++ b/bin/elevate.cmd
@@ -1,0 +1,10 @@
+@setlocal
+@echo off
+
+%*
+if %ERRORLEVEL% LSS 1 goto :EOF
+
+:: The command failed without elevation, try with elevation
+set CMD=%*
+set APP=%1
+start wscript //nologo "%~dpn0.vbs" %*

--- a/bin/elevate.vbs
+++ b/bin/elevate.vbs
@@ -1,0 +1,13 @@
+Set Shell = CreateObject("Shell.Application")
+Set WShell = WScript.CreateObject("WScript.Shell")
+Set ProcEnv = WShell.Environment("PROCESS")
+
+cmd = ProcEnv("CMD")
+app = ProcEnv("APP")
+args= Right(cmd,(Len(cmd)-Len(app)))
+
+If (WScript.Arguments.Count >= 1) Then
+  Shell.ShellExecute app, args, "", "runas", 0
+Else
+  WScript.Quit
+End If

--- a/cli/fileperms_win.go
+++ b/cli/fileperms_win.go
@@ -7,9 +7,7 @@
 package cli
 
 import (
-	"bytes"
 	"os"
-	"os/exec"
 )
 
 func canModifyFile(path string) (bool, error) {
@@ -44,27 +42,4 @@ func canModifyFile(path string) (bool, error) {
 	// }
 
 	return false, nil
-}
-
-func elevatedRun(name string, arg ...string) (bool, error) {
-	ok, err := run("cmd", nil, append([]string{"/C", name}, arg...)...)
-	if err != nil {
-		ok, err = run("elevate.cmd", nil, append([]string{"cmd", "/C", name}, arg...)...)
-	}
-	return ok, err
-}
-
-func run(name string, dir *string, arg ...string) (bool, error) {
-	c := exec.Command(name, arg...)
-	if dir != nil {
-		c.Dir = *dir
-	}
-	var stderr bytes.Buffer
-	c.Stderr = &stderr
-	err := c.Run()
-	if err != nil {
-		return false, err
-	}
-
-	return true, nil
 }

--- a/cli/fileperms_win.go
+++ b/cli/fileperms_win.go
@@ -6,9 +6,7 @@
 
 package cli
 
-import (
-	"os"
-)
+import "os"
 
 func canModifyFile(path string) (bool, error) {
 	fileInfo, err := os.Stat(path)

--- a/cli/fileperms_win.go
+++ b/cli/fileperms_win.go
@@ -6,7 +6,11 @@
 
 package cli
 
-import "os"
+import (
+	"bytes"
+	"os"
+	"os/exec"
+)
 
 func canModifyFile(path string) (bool, error) {
 	fileInfo, err := os.Stat(path)
@@ -40,4 +44,27 @@ func canModifyFile(path string) (bool, error) {
 	// }
 
 	return false, nil
+}
+
+func elevatedRun(name string, arg ...string) (bool, error) {
+	ok, err := run("cmd", nil, append([]string{"/C", name}, arg...)...)
+	if err != nil {
+		ok, err = run("elevate.cmd", nil, append([]string{"cmd", "/C", name}, arg...)...)
+	}
+	return ok, err
+}
+
+func run(name string, dir *string, arg ...string) (bool, error) {
+	c := exec.Command(name, arg...)
+	if dir != nil {
+		c.Dir = *dir
+	}
+	var stderr bytes.Buffer
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/cli/install.go
+++ b/cli/install.go
@@ -12,8 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/schollz/progressbar/v3"
-	"github.com/tristanisham/zvm/cli/meta"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,6 +20,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/schollz/progressbar/v3"
+	"github.com/tristanisham/zvm/cli/meta"
 
 	"github.com/charmbracelet/log"
 
@@ -404,9 +405,14 @@ func (z *ZVM) createSymlink(version string) {
 
 	}
 
-	if err := os.Symlink(filepath.Join(z.baseDir, version), filepath.Join(z.baseDir, "bin")); err != nil {
-		log.Fatal(err)
+	if runtime.GOOS == "windows" {
+		elevatedRun("mklink", "/D", filepath.Join(z.baseDir, "bin"), filepath.Join(z.baseDir, version))
+	} else {
+		if err := os.Symlink(filepath.Join(z.baseDir, version), filepath.Join(z.baseDir, "bin")); err != nil {
+			log.Fatal(err)
+		}
 	}
+
 }
 
 func getTarPath(version string, data *map[string]map[string]any) (string, error) {

--- a/cli/use.go
+++ b/cli/use.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -39,8 +40,20 @@ func (z *ZVM) setBin(ver string) error {
 		log.Warn(err)
 	}
 
-	if err := os.Symlink(version_path, filepath.Join(z.baseDir, "bin")); err != nil {
-		return err
+	if runtime.GOOS == "windows" {
+		elevatedRun("mklink", "/D", filepath.Join(z.baseDir, "bin"), filepath.Join(z.baseDir, ver))
+	} else {
+		if err := os.Symlink(filepath.Join(z.baseDir, ver), filepath.Join(z.baseDir, "bin")); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if runtime.GOOS == "windows" {
+		elevatedRun("mklink", "/D", filepath.Join(z.baseDir, "bin"), version_path)
+	} else {
+		if err := os.Symlink(version_path, filepath.Join(z.baseDir, "bin")); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cli/user_perm_win.go
+++ b/cli/user_perm_win.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func elevatedRun(name string, arg ...string) (bool, error) {
+	ok, err := run("cmd", nil, append([]string{"/C", name}, arg...)...)
+	if err != nil {
+		ok, err = run("elevate.cmd", nil, append([]string{"cmd", "/C", name}, arg...)...)
+	}
+	return ok, err
+}
+
+func run(name string, dir *string, arg ...string) (bool, error) {
+	c := exec.Command(name, arg...)
+	if dir != nil {
+		c.Dir = *dir
+	}
+	var stderr bytes.Buffer
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/install.ps1
+++ b/install.ps1
@@ -12,6 +12,8 @@ function Install-ZVM {
     $ZipPath = "${ZVMSelf}\$Target"
 
     $null = mkdir -Force $ZVMSelf
+    curl.exe "-#SfLo" "$ZVMSelf/elevate.cmd" "https://raw.githubusercontent.com/tristanisham/zvm/master/bin/elevate.cmd" -s
+    curl.exe "-#SfLo" "$ZVMSelf/elevate.vbs" "https://raw.githubusercontent.com/tristanisham/zvm/master/bin/elevate.vbs" -s
     Remove-Item -Force $ZipPath -ErrorAction SilentlyContinue
     curl.exe "-#SfLo" "$ZipPath" "$URL" 
     if ($LASTEXITCODE -ne 0) {
@@ -65,6 +67,14 @@ function Install-ZVM {
 
     $User = [System.EnvironmentVariableTarget]::User
     $Path = [System.Environment]::GetEnvironmentVariable('Path', $User) -split ';'
+    $ZVMInstall = 'ZVM_INSTALL'
+
+    $ZVMInstallValue = [System.Environment]::GetEnvironmentVariable($ZVMInstall, [System.EnvironmentVariableTarget]::User)
+
+    if ($null -eq $ZVMInstallValue) {
+        [System.Environment]::SetEnvironmentVariable($ZVMInstall, $ZVMSelf, [System.EnvironmentVariableTarget]::User)
+    }
+
     if ($Path -notcontains $ZVMSelf) {
         $Path += $ZVMSelf
         [System.Environment]::SetEnvironmentVariable('Path', $Path -join ';', $User)
@@ -80,6 +90,7 @@ function Install-ZVM {
     if ($env:PATH -notcontains ";${ZVMBin}") {
         $env:PATH = "${env:Path};${ZVMBin}"
     }
+
     Write-Output "To get started, restart your terminal/editor, then type `"zvm`"`n"
 }
 


### PR DESCRIPTION
Closes #59 

This feature allows the execution of `zvm install` and `zvm use` commands successfully without the need to explicitly open the command prompt in administrator mode. When these commands are run in a terminal without administrative privileges, a popup will appear, requesting elevation to administrator mode