### PR TITLE
Small typo during installation

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -201,7 +201,7 @@ func (z *ZVM) Install(version string) error {
 
 	z.createSymlink(version)
 
-	fmt.Println("Succsessfully installed Zig!")
+	fmt.Println("Successfully installed Zig!")
 
 	return nil
 }


### PR DESCRIPTION
Changed "Succsessfully" to "Successfully"