### PR TITLE
FIX: proper creation of the "bin" dir on Windows

### DIFF
--- a/cli/use.go
+++ b/cli/use.go
@@ -37,14 +37,20 @@ func (z *ZVM) Use(ver string) error {
 func (z *ZVM) setBin(ver string) error {
 	// .zvm/master
 	version_path := filepath.Join(z.baseDir, ver)
-	if err := os.Remove(filepath.Join(z.baseDir, "bin")); err != nil {
-		return err
+	bin_dir := filepath.Join(z.baseDir, "bin")
+
+	// Remove "bin" dir only if it already exists
+	_, err := os.Stat(bin_dir)
+	if !os.IsNotExist(err) {
+		fmt.Printf("Removing old %s", bin_dir)
+		if err := os.Remove(bin_dir); err != nil {
+			return err
+		}
 	}
 
-	if err := meta.Symlink(version_path, filepath.Join(z.baseDir, "bin")); err != nil {
+	if err := meta.Symlink(version_path, bin_dir); err != nil {
 		return err
 	}
-
 
 	return nil
 }


### PR DESCRIPTION
@tristanisham Hey thank you for all the work on zvm, I use it frequently on my macOS system and it works like a charm. However I had some issues on Windows and tried to fix them:

### 1. Remove and linking the `bin` alias
I had the following issue on my Windows machine: 
`zvm` would never create the initial "bin" directory (or symlink) in `~/.zvm`, as it always tries to remove the "bin" directory first [here](https://github.com/tristanisham/zvm/blob/a7f1a2c429831b07d2b2dbd4eaf39ab212ec77cb/cli/use.go#L40) and returns if that fails.

I changed this to first check if the `bin` alias is even present and only delete it if it exists. Then afterwards the symlink to the selected version is created.

Might be related to [#62](https://github.com/tristanisham/zvm/issues/62)


---

### 2. Privileges
On my Windows machine the call `errors.Is(err, &os.LinkError{})`, here:
    https://github.com/tristanisham/zvm/blob/a7f1a2c429831b07d2b2dbd4eaf39ab212ec77cb/cli/meta/symlink_win.go#L57

always returned "false", so it was never creating the "bin" symlink at all. Not a proficient Go dev here, but it looks like we need to compare the actual error to a syscall error and handle these?

Anyway I solved it differently by checking for `isAdmin()` first, then try to become admin if not already and otherwise just create the link to "bin". This way I even get the Windows User Account prompt if I want to allow the program to make the change.