### PR TITLE
Improve error reporting for ZLS installs

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -275,6 +275,10 @@ func getZLSDownloadUrl(version string, archDouble string) (string, error) {
 			return "", err
 		}
 
+		if len(taggedReleaseResponse.Assets) == 0 {
+			return "", errors.New("invalid ZLS version")
+		}
+
 		// getting platform information
 		var downloadUrl string
 		for _, asset := range taggedReleaseResponse.Assets {
@@ -285,7 +289,7 @@ func getZLSDownloadUrl(version string, archDouble string) (string, error) {
 		}
 
 		if downloadUrl == "" {
-			return "", errors.New("invalid release URl")
+			return "", errors.New("invalid ZLS release URL")
 		}
 
 		return downloadUrl, nil

--- a/main.go
+++ b/main.go
@@ -110,8 +110,10 @@ func main() {
 			if *installDeps != "" {
 				switch *installDeps {
 				case "zls":
-					
-					zvm.InstallZls(req.Package)
+
+					if err := zvm.InstallZls(req.Package); err != nil {
+						meta.CtaFatal(err)
+					}
 				}
 			}
 


### PR DESCRIPTION
This commit improves (enables at all, lol?) errors reported to the user regarding problems with downloading ZLS.

Currently, ZVM silently fails to install ZLS if there is a version mismatch between Zig and ZLS. For instance, the latest release of Zig is `0.12.0` but the latest ZLS is `0.11.0`.

This PR does not resolve determining if a mismatch exists, but does at least report (somewhat) useful errors to the user.