### PR TITLE
🐛 Remove "bin" from zls rename location

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -385,12 +385,10 @@ func (z *ZVM) InstallZls(version string) error {
 		}
 
 		fmt.Println("Extracting ZLS...")
-		if err := ExtractBundle(tempDir.Name(), filepath.Join(z.baseDir, version)); err != nil {
+		if err := ExtractBundle(tempDir.Name(), versionPath); err != nil {
 			log.Fatal(err)
 		}
-		if err := os.Rename(filepath.Join(versionPath, filename), filepath.Join(versionPath, filename)); err != nil {
-			return err
-		}
+		
 	}
 
 	if err := os.Chmod(filepath.Join(versionPath, filename), 0755); err != nil {

--- a/cli/install.go
+++ b/cli/install.go
@@ -388,7 +388,7 @@ func (z *ZVM) InstallZls(version string) error {
 		if err := ExtractBundle(tempDir.Name(), filepath.Join(z.baseDir, version)); err != nil {
 			log.Fatal(err)
 		}
-		if err := os.Rename(filepath.Join(versionPath, "bin", filename), filepath.Join(versionPath, filename)); err != nil {
+		if err := os.Rename(filepath.Join(versionPath, filename), filepath.Join(versionPath, filename)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Remove bin because the zls zip has the files in the root location of the zip, not in the "bin" directory.