### PR TITLE
Follow XDG Specification for ZVM Installation

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,6 @@ jobs:
           - "ubuntu"
           - "fedora"
           - "archlinux"
-          - "gentoo"
           - "opensuse/leap"
     container: '${{ matrix.os }}'
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,23 @@
+name: Linux Installation Tests
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+    
+jobs:
+  container-test-job:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+          - fedora
+          - manjaro
+          - gentoo
+          - opensuse
+    container: '${{ matrix.os }}-image'
+    steps:
+      - name: Print Distro Info
+        run: cat /etc/os-release
+        shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,8 +14,9 @@ jobs:
           - "ubuntu"
           - "fedora"
           - "archlinux"
-          - "opensuse/leap"
-    container: '${{ matrix.os }}'
+    container:
+      image: '${{ matrix.os }}'
+    
     steps:
       - name: Print Distro Info
         run: cat /etc/os-release
@@ -25,16 +26,13 @@ jobs:
         run: |
           case ${{ matrix.os }} in
             ubuntu)
-              apt-get update && apt-get upgrade -y && apt-get install -y git
+              apt-get update && apt-get upgrade -y && apt-get install -y git curl xz-utils
               ;;
             fedora)
-              dnf update -y && dnf install -y git
+              dnf update -y && dnf install -y git wget2 xz
               ;;
             archlinux)
-              pacman -Syu --noconfirm && pacman -S --noconfirm git
-              ;;
-            opensuse/leap)
-              zypper refresh && zypper update -y && zypper install -y git
+              pacman -Syu --noconfirm && pacman -S --noconfirm git wget xz
               ;;
           esac
         shell: bash
@@ -42,4 +40,58 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install ZVM
-        run: cat install.sh | bash
+        run: | 
+          cat install.sh | bash
+          echo "XDG_DATA_HOME=${HOME}/.local/share" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Setting up ZVM_PATH
+        run: |
+          echo "ZVM_PATH=${XDG_DATA_HOME}/zvm" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Update PATH
+        run: |
+          echo "${ZVM_PATH}/bin" >> $GITHUB_PATH
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Verify Environment Variables and PATH
+        run: |
+          echo "XDG_DATA_HOME is set to $XDG_DATA_HOME"
+          echo "ZVM_PATH is set to $ZVM_PATH"
+        shell: bash
+
+      - name: Verify ZVM Installation
+        run: |
+          ls -alF $ZVM_PATH
+          ls -alF ${HOME}/.local/bin
+
+          if [ ! -f "$ZVM_PATH/self/zvm" ]; then
+            echo "zvm binary not found in $ZVM_PATH/self"
+            exit 1
+          fi
+
+          zvm --version
+        shell: bash
+      
+      - name: Installing Zig and verifying symlink
+        run: |
+          zvm i 0.13.0
+
+          if [ "$(readlink -e $ZVM_PATH/bin)" != "$ZVM_PATH/0.13.0" ]; then
+            echo "readlink -e $ZVM_PATH/bin does not return $ZVM_PATH/0.13.0"
+            exit 1
+          fi
+
+          zvm i master
+          if [ "$(readlink -e $ZVM_PATH/bin)" != "$ZVM_PATH/master" ]; then
+            echo "readlink -e $ZVM_PATH/bin does not return $ZVM_PATH/0.13.0"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Verifing Zig Path
+        run: |
+          zig version
+        shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu
-          - fedora
-          - manjaro
-          - gentoo
-          - opensuse
-    container: '${{ matrix.os }}-image'
+          - "ubuntu"
+          - "fedora"
+          - "archlinux"
+          - "gentoo"
+          - "opensuse/leap"
+    container: '${{ matrix.os }}'
     steps:
       - name: Print Distro Info
         run: cat /etc/os-release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Installing Zig and verifying symlink
         run: |
           zvm i 0.13.0
+          ls -alF $ZVM_PATH
 
           if [ "$(readlink -e $ZVM_PATH/bin)" != "$ZVM_PATH/0.13.0" ]; then
             echo "readlink -e $ZVM_PATH/bin does not return $ZVM_PATH/0.13.0"
@@ -85,6 +86,8 @@ jobs:
           fi
 
           zvm i master
+          ls -alF $ZVM_PATH
+          
           if [ "$(readlink -e $ZVM_PATH/bin)" != "$ZVM_PATH/master" ]; then
             echo "readlink -e $ZVM_PATH/bin does not return $ZVM_PATH/0.13.0"
             exit 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,3 +20,8 @@ jobs:
       - name: Print Distro Info
         run: cat /etc/os-release
         shell: bash
+      
+      - uses: actions/checkout@v4
+
+      - name: Install ZVM
+        run: cat install.sh | bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,16 +24,16 @@ jobs:
       - name: Update System and Git
         run: |
           case ${{ matrix.os }} in
-            ubuntu:latest)
+            ubuntu)
               apt-get update && apt-get upgrade -y && apt-get install -y git
               ;;
-            fedora:latest)
+            fedora)
               dnf update -y && dnf install -y git
               ;;
-            archlinux:latest)
+            archlinux)
               pacman -Syu --noconfirm && pacman -S --noconfirm git
               ;;
-            opensuse:latest)
+            opensuse/leap)
               zypper refresh && zypper update -y && zypper install -y git
               ;;
           esac

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,24 @@ jobs:
         run: cat /etc/os-release
         shell: bash
       
+      - name: Update System and Git
+        run: |
+          case ${{ matrix.os }} in
+            ubuntu:latest)
+              apt-get update && apt-get upgrade -y && apt-get install -y git
+              ;;
+            fedora:latest)
+              dnf update -y && dnf install -y git
+              ;;
+            archlinux:latest)
+              pacman -Syu --noconfirm && pacman -S --noconfirm git
+              ;;
+            opensuse:latest)
+              zypper refresh && zypper update -y && zypper install -y git
+              ;;
+          esac
+        shell: bash
+
       - uses: actions/checkout@v4
 
       - name: Install ZVM

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,10 +26,10 @@ jobs:
         run: |
           case ${{ matrix.os }} in
             ubuntu)
-              apt-get update && apt-get upgrade -y && apt-get install -y git curl xz-utils
+              apt-get update && apt-get upgrade -y && apt-get install -y git wget2 xz-utils
               ;;
             fedora)
-              dnf update -y && dnf install -y git wget2 xz
+              dnf update -y && dnf install -y git curl xz
               ;;
             archlinux)
               pacman -Syu --noconfirm && pacman -S --noconfirm git wget xz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,83 @@
+name: Mac OS Installation Tests
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+    
+jobs:
+    test-job:
+        runs-on: "macos-latest"
+    
+        steps:
+            - name: Print Distro Info
+              run: sw_vers
+              shell: bash
+            
+            - name: Update System and Git
+              run: |
+                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
+                brew update
+                brew upgrade
+                brew install git curl xz
+              shell: bash
+      
+            - uses: actions/checkout@v4
+      
+            - name: Install ZVM
+              run: | 
+                cat install.sh | bash
+              shell: bash
+      
+            - name: Setting up ZVM_PATH
+              run: |
+                echo "ZVM_PATH=${HOME}/Library/zvm" >> $GITHUB_ENV
+              shell: bash
+      
+            - name: Update PATH
+              run: |
+                echo "${ZVM_PATH}/bin" >> $GITHUB_PATH
+                echo "${HOME}/bin" >> $GITHUB_PATH
+              shell: bash
+      
+            - name: Verify Environment Variables and PATH
+              run: |
+                echo "ZVM_PATH is set to $ZVM_PATH"
+              shell: bash
+      
+            - name: Verify ZVM Installation
+              run: |
+                ls -alF $ZVM_PATH
+                ls -alF ${HOME}/bin
+      
+                if [ ! -f "$ZVM_PATH/self/zvm" ]; then
+                  echo "zvm binary not found in $ZVM_PATH/self"
+                  exit 1
+                fi
+      
+                zvm --version
+              shell: bash
+            
+            - name: Installing Zig and verifying symlink
+              run: |
+                zvm i 0.13.0
+                ls -alF $ZVM_PATH
+      
+                if [ "$(readlink -f $ZVM_PATH/bin)" != "$ZVM_PATH/0.13.0" ]; then
+                  echo "readlink -f $ZVM_PATH/bin does not return $ZVM_PATH/0.13.0"
+                  exit 1
+                fi
+      
+                zvm i master
+                ls -alF $ZVM_PATH
+                
+                if [ "$(readlink -f $ZVM_PATH/bin)" != "$ZVM_PATH/master" ]; then
+                  echo "readlink -f $ZVM_PATH/bin does not return $ZVM_PATH/0.13.0"
+                  exit 1
+                fi
+              shell: bash
+      
+            - name: Verifing Zig Path
+              run: |
+                zig version
+              shell: bash

--- a/install.sh
+++ b/install.sh
@@ -15,12 +15,25 @@ fi
 # echo "Installing zvm-$OS-$ARCH"
 
 install_latest() {
-    echo -e "Installing $1 in $(pwd)/zvm"
     if [ "$(uname)" = "Darwin" ]; then
-        # Do something under MacOS platform
+        # MacOS platform
+        install_dir="$HOME/Library/zvm/self"
+        bin_dir="$HOME/bin"
+    elif [ "$OS" = "Linux" ]; then
+        # GNU/Linux platform
+        install_dir="$XDG_DATA_HOME/zvm/self"
+        bin_dir="$HOME/.local/bin"
+    else
+        # Other OSes
+        install_dir="$HOME/.zvm"
+        bin_dir="$HOME/.zvm/bin"
+    fi
 
+    echo -e "Installing $1 in $install_dir"
+
+    if [ "$(uname)" = "Darwin" ]; then
+        # MacOS platform
         if command -v wget >/dev/null 2>&1; then
-
             echo "wget is installed. Using wget..."
             wget -q --show-progress --max-redirect 5 -O zvm.tar "https://github.com/tristanisham/zvm/releases/latest/download/$1"
         else
@@ -28,15 +41,14 @@ install_latest() {
             curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.tar
         fi
 
-        mkdir -p $HOME/Library/zvm/self
-        tar -xf zvm.tar -C $HOME/Library/zvm/self
-        ln -s $HOME/Library/zvm/self/zvm $HOME/bin
+        mkdir -p "$install_dir"
+        tar -xf zvm.tar -C "$install_dir"
+        ln -s "$install_dir/zvm" "$bin_dir"
         rm "zvm.tar"
 
-    elif [ $OS = "Linux" ]; then
-        # Do something under GNU/Linux platform
+    elif [ "$OS" = "Linux" ]; then
+        # GNU/Linux platform
         if command -v wget >/dev/null 2>&1; then
-
             echo "wget is installed. Using wget..."
             wget -q --show-progress --max-redirect 5 -O zvm.tar "https://github.com/tristanisham/zvm/releases/latest/download/$1"
         else
@@ -44,18 +56,20 @@ install_latest() {
             curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.tar
         fi
 
-        mkdir -p $XDG_DATA_HOME/zvm/self
-        tar -xf zvm.tar -C $XDG_DATA_HOME/zvm/self
-        ln -s $XDG_DATA_HOME/zvm/self/zvm $HOME/.local/bin
+        mkdir -p "$install_dir"
+        tar -xf zvm.tar -C "$install_dir"
+        ln -s "$install_dir/zvm" "$bin_dir"
         rm "zvm.tar"
-    elif [ $OS = "MINGW32_NT" ]; then
-        # Do something under 32 bits Windows NT platform
-        curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$($1)" -o zvm.zip
 
-    elif [ $OS == "MINGW64_NT" ]; then
-        # Do something under 64 bits Windows NT platform
-        curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$($1)" -o zvm.zip
+    elif [ "$OS" = "MINGW32_NT" ]; then
+        # 32 bits Windows NT platform
+        curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.zip
+        # Add extraction and installation commands as needed
 
+    elif [ "$OS" = "MINGW64_NT" ]; then
+        # 64 bits Windows NT platform
+        curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.zip
+        # Add extraction and installation commands as needed
     fi
 }
 
@@ -88,8 +102,8 @@ if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM" == "screen" |
     echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$XDG_DATA_HOME/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# Linux${NC}"
     echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$HOME/Library/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# macOS${NC}"
 
-    echo "Make sure ${RED}\$HOME/.local/bin${NC} is in your PATH on Linux."
-    echo "Make sure ${RED}\$HOME/bin${NC} is in your PATH on macOS."
+    echo -e "Make sure ${RED}\$HOME/.local/bin${NC} is in your PATH on Linux."
+    echo -e "Make sure ${RED}\$HOME/bin${NC} is in your PATH on macOS."
 
     echo "Run 'zvm i master' to install Zig"
 else

--- a/install.sh
+++ b/install.sh
@@ -2,11 +2,8 @@
 
 # ZVM install script - v0.1.5 - ZVM: https://github.com/tristanisham/zvm
 
-
-
 ARCH=$(uname -m)
 OS=$(uname -s)
-
 
 if [ $ARCH = "aarch64" ]; then
     ARCH="arm64"
@@ -20,53 +17,53 @@ fi
 install_latest() {
     echo -e "Installing $1 in $(pwd)/zvm"
     if [ "$(uname)" = "Darwin" ]; then
-     # Do something under MacOS platform
+        # Do something under MacOS platform
 
         if command -v wget >/dev/null 2>&1; then
-    
+
             echo "wget is installed. Using wget..."
             wget -q --show-progress --max-redirect 5 -O zvm.tar "https://github.com/tristanisham/zvm/releases/latest/download/$1"
         else
             echo "wget is not installed. Using curl..."
             curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.tar
         fi
-        
-        mkdir -p $HOME/.zvm/self
-        tar -xf zvm.tar -C $HOME/.zvm/self
+
+        mkdir -p $HOME/Library/zvm/self
+        tar -xf zvm.tar -C $HOME/Library/zvm/self
+        ln -s $HOME/Library/zvm/self/zvm $HOME/bin
         rm "zvm.tar"
-        
+
     elif [ $OS = "Linux" ]; then
-     # Do something under GNU/Linux platform
+        # Do something under GNU/Linux platform
         if command -v wget >/dev/null 2>&1; then
-    
+
             echo "wget is installed. Using wget..."
             wget -q --show-progress --max-redirect 5 -O zvm.tar "https://github.com/tristanisham/zvm/releases/latest/download/$1"
         else
             echo "wget is not installed. Using curl..."
             curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.tar
         fi
-        
-        mkdir -p $HOME/.zvm/self
-        tar -xf zvm.tar -C $HOME/.zvm/self
+
+        mkdir -p $XDG_DATA_HOME/zvm/self
+        tar -xf zvm.tar -C $XDG_DATA_HOME/zvm/self
+        ln -s $XDG_DATA_HOME/zvm/self/zvm $HOME/.local/bin
         rm "zvm.tar"
     elif [ $OS = "MINGW32_NT" ]; then
-    # Do something under 32 bits Windows NT platform
+        # Do something under 32 bits Windows NT platform
         curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$($1)" -o zvm.zip
 
     elif [ $OS == "MINGW64_NT" ]; then
-    # Do something under 64 bits Windows NT platform
+        # Do something under 64 bits Windows NT platform
         curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$($1)" -o zvm.zip
 
     fi
 }
 
-
-
 if [ "$(uname)" = "Darwin" ]; then
     # Do something under Mac OS X platform
     install_latest "zvm-darwin-$ARCH.tar"
 elif [ $OS = "Linux" ]; then
-     # Do something under GNU/Linux platform
+    # Do something under GNU/Linux platform
     install_latest "zvm-linux-$ARCH.tar"
 elif [ $OS = "MINGW32_NT" ]; then
     # Do something under 32 bits Windows NT platform
@@ -78,14 +75,14 @@ fi
 
 echo
 echo "Run the following commands to put ZVM on your path via $HOME/.profile"
-echo 
+echo
 # Check if TERM is set to a value that typically supports colors
 if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM" == "screen" || "$TERM" == "tmux" ]]; then
     # Colors
-    RED='\033[0;31m'        # For strings
-    GREEN='\033[0;32m'      # For commands
-    BLUE='\033[0;34m'       # For variables
-    NC='\033[0m'            # No Color
+    RED='\033[0;31m'   # For strings
+    GREEN='\033[0;32m' # For commands
+    BLUE='\033[0;34m'  # For variables
+    NC='\033[0m'       # No Color
 
     echo -e "${GREEN}echo${NC} ${RED}\"# ZVM\"${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
     echo -e "${GREEN}echo${NC} ${RED}'export ZVM_INSTALL=\"\$HOME/.zvm/self\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
@@ -103,5 +100,5 @@ else
     echo "Run 'source ~/.profile' to start using ZVM in this shell!"
     echo "Run 'zvm i master' to install Zig"
 fi
-    
+
 echo

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,7 @@ if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM" == "screen" |
     echo -e "${GREEN}echo${NC} ${RED}\"# ZVM\"${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
     echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$XDG_DATA_HOME/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# Linux${NC}"
     echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$HOME/Library/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# macOS${NC}"
+    echo -e "${GREEN}echo${NC} ${RED}'export PATH=\"\$PATH:\$ZVM_PATH/bin\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
 
     echo -e "Make sure ${RED}\$HOME/.local/bin${NC} is in your PATH on Linux."
     echo -e "Make sure ${RED}\$HOME/bin${NC} is in your PATH on macOS."
@@ -110,6 +111,7 @@ else
     echo 'echo "# ZVM" >> $HOME/.profile'
     echo 'echo '\''export ZVM_PATH="$XDG_DATA_HOME/zvm"'\'' >> $HOME/.profile # Linux'
     echo 'echo '\''export ZVM_PATH="$HOME/Library/zvm"'\'' >> $HOME/.profile # macOS'
+    echo 'echo '\''export PATH="$PATH:$ZVM_PATH/bin"'\'' >> $HOME/.profile'
 
     echo "Make sure \$HOME/.local/bin is in your PATH on Linux."
     echo "Make sure \$HOME/bin is in your PATH on macOS."

--- a/install.sh
+++ b/install.sh
@@ -1,122 +1,139 @@
 #!/usr/bin/env bash
 
 # ZVM install script - v0.1.5 - ZVM: https://github.com/tristanisham/zvm
-
 ARCH=$(uname -m)
 OS=$(uname -s)
 
-if [ $ARCH = "aarch64" ]; then
-    ARCH="arm64"
-fi
-if [ $ARCH = "x86_64" ]; then
-    ARCH="amd64"
-fi
+post_install_setup() {
+    if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM" == "screen" || "$TERM" == "tmux" ]]; then
+        # Colors
+        RED='\033[0;31m'   # For errors
+        GREEN='\033[0;32m' # For commands
+        BLUE='\033[0;34m'  # For variables
+        NC='\033[0m'       # No Color
 
-# echo "Installing zvm-$OS-$ARCH"
+        echo -e "${GREEN}To complete the setup, add the following lines to your .bashrc or .profile file:${NC}"
 
-install_latest() {
-    if [ "$(uname)" = "Darwin" ]; then
-        # MacOS platform
-        install_dir="$HOME/Library/zvm/self"
-        bin_dir="$HOME/bin"
-    elif [ "$OS" = "Linux" ]; then
-        # GNU/Linux platform
-        install_dir="$XDG_DATA_HOME/zvm/self"
-        bin_dir="$HOME/.local/bin"
+        echo
+        echo -e "${BLUE}# ZVM${NC}"
+
+        if [[ "$OS" == "Linux" ]]; then
+            # Linux Instructions
+            echo -e "export ZVM_PATH=\"${BLUE}\$XDG_DATA_HOME/zvm${NC}\""
+            echo -e "export PATH=\"\${PATH}:${BLUE}\$ZVM_PATH/bin${NC}\""
+            echo -e "${GREEN}Ensure that ${BLUE}\$HOME/.local/bin${NC} is in your PATH on Linux."
+        elif [[ "$OS" == "Darwin" ]]; then
+            # macOS Instructions
+            echo -e "export ZVM_PATH=\"${BLUE}\$HOME/Library/zvm${NC}\""
+            echo -e "export PATH=\"\${PATH}:${BLUE}\$ZVM_PATH/bin${NC}\""
+            echo -e "${GREEN}Ensure that ${BLUE}\$HOME/bin${NC} is in your PATH on macOS."
+        else
+            # OS not supported
+            echo -e "${RED}Your OS ($OS) is not supported by this script.${NC}"
+        fi
     else
-        # Other OSes
-        install_dir="$HOME/.zvm"
-        bin_dir="$HOME/.zvm/bin"
+        echo "To complete the setup, add the following lines to your .bashrc or .profile file:"
+
+        echo
+        echo "# ZVM"
+
+        if [[ "$OS" == "Linux" ]]; then
+            # Linux Instructions
+            echo "export ZVM_PATH=\"\$XDG_DATA_HOME/zvm\""
+            echo "export PATH=\"\$PATH:\$ZVM_PATH/bin\""
+            echo "Ensure that \$HOME/.local/bin is in your PATH on Linux."
+        elif [[ "$OS" == "Darwin" ]]; then
+            # macOS Instructions
+            echo "export ZVM_PATH=\"\$HOME/Library/zvm\""
+            echo "export PATH=\"\$PATH:\$ZVM_PATH/bin\""
+            echo "Ensure that \$HOME/bin is in your PATH on macOS."
+        else
+            # OS not supported
+            echo "Your OS ($OS) is not supported by this script."
+        fi
     fi
 
-    echo -e "Installing $1 in $install_dir"
+    echo
+    echo "Run 'zvm i master' to install Zig"
+}
 
-    if [ "$(uname)" = "Darwin" ]; then
-        # MacOS platform
-        if command -v wget >/dev/null 2>&1; then
-            echo "wget is installed. Using wget..."
-            wget -q --show-progress --max-redirect 5 -O zvm.tar "https://github.com/tristanisham/zvm/releases/latest/download/$1"
-        else
-            echo "wget is not installed. Using curl..."
-            curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.tar
-        fi
+download_file() {
+    local url="$1"
+    local output_filename="$2"
 
-        mkdir -p "$install_dir"
-        tar -xf zvm.tar -C "$install_dir"
-        ln -s "$install_dir/zvm" "$bin_dir"
-        rm "zvm.tar"
-
-    elif [ "$OS" = "Linux" ]; then
-        # GNU/Linux platform
-        if command -v wget >/dev/null 2>&1; then
-            echo "wget is installed. Using wget..."
-            wget -q --show-progress --max-redirect 5 -O zvm.tar "https://github.com/tristanisham/zvm/releases/latest/download/$1"
-        else
-            echo "wget is not installed. Using curl..."
-            curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.tar
-        fi
-
-        mkdir -p "$install_dir"
-        tar -xf zvm.tar -C "$install_dir"
-        ln -s "$install_dir/zvm" "$bin_dir"
-        rm "zvm.tar"
-
-    elif [ "$OS" = "MINGW32_NT" ]; then
-        # 32 bits Windows NT platform
-        curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.zip
-        # Add extraction and installation commands as needed
-
-    elif [ "$OS" = "MINGW64_NT" ]; then
-        # 64 bits Windows NT platform
-        curl -L --max-redirs 5 "https://github.com/tristanisham/zvm/releases/latest/download/$1" -o zvm.zip
-        # Add extraction and installation commands as needed
+    if command -v wget >/dev/null 2>&1; then
+        echo "wget is installed. Using wget..."
+        wget -q --show-progress --max-redirect 5 -O "$output_filename" "$url"
+    elif command -v curl >/dev/null 2>&1; then
+        echo "wget is not installed. Using curl..."
+        curl -L --max-redirs 5 "$url" -o "$output_filename"
+    elif command -v wget2 >/dev/null 2>&1; then
+        echo "wget and curl are not installed. Using wget2..."
+        wget2 -q --progress=bar --max-redirect 5 -O "$output_filename" "$url"
+    else
+        echo "Neither wget, curl, nor wget2 is installed. Please install one of these tools to proceed."
+        return 1
     fi
 }
 
-if [ "$(uname)" = "Darwin" ]; then
-    # Do something under Mac OS X platform
-    install_latest "zvm-darwin-$ARCH.tar"
-elif [ $OS = "Linux" ]; then
-    # Do something under GNU/Linux platform
-    install_latest "zvm-linux-$ARCH.tar"
-elif [ $OS = "MINGW32_NT" ]; then
-    # Do something under 32 bits Windows NT platform
-    install_latest "zvm-windows-$ARCH.zip"
-elif [ $OS == "MINGW64_NT" ]; then
-    # Do something under 64 bits Windows NT platform
-    install_latest "zvm-windows-$ARCH.zip"
-fi
+install_zvm() {
+    local install_dir
+    local bin_dir
 
-echo
-echo "Run the following commands to put ZVM on your path via $HOME/.profile"
-echo
-# Check if TERM is set to a value that typically supports colors
-if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM" == "screen" || "$TERM" == "tmux" ]]; then
-    # Colors
-    RED='\033[0;31m'   # For strings
-    GREEN='\033[0;32m' # For commands
-    BLUE='\033[0;34m'  # For variables
-    NC='\033[0m'       # No Color
+    case "$OS" in
+    "Darwin")
+        # MacOS platform
+        install_dir="$HOME/Library/zvm/self"
+        bin_dir="$HOME/bin"
+        ;;
+    "Linux")
+        # GNU/Linux platform
+        install_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zvm/self"
+        bin_dir="$HOME/.local/bin"
+        ;;
+    *)
+        # Other OSes
+        install_dir="$HOME/.zvm"
+        bin_dir="$HOME/.zvm/bin"
+        ;;
+    esac
 
-    echo -e "${GREEN}echo${NC} ${RED}\"# ZVM\"${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
-    echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$XDG_DATA_HOME/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# Linux${NC}"
-    echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$HOME/Library/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# macOS${NC}"
-    echo -e "${GREEN}echo${NC} ${RED}'export PATH=\"\$PATH:\$ZVM_PATH/bin\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
+    # Check if the installation directory already exists
+    if [ -d "$install_dir" ]; then
+        echo "Error: zvm is already installed. Please remove the directory $install_dir to reinstall."
+        return 1
+    fi
 
-    echo -e "Make sure ${RED}\$HOME/.local/bin${NC} is in your PATH on Linux."
-    echo -e "Make sure ${RED}\$HOME/bin${NC} is in your PATH on macOS."
+    download_file "https://github.com/tristanisham/zvm/releases/latest/download/$1" "zvm.zip"
 
-    echo "Run 'zvm i master' to install Zig"
-else
-    echo 'echo "# ZVM" >> $HOME/.profile'
-    echo 'echo '\''export ZVM_PATH="$XDG_DATA_HOME/zvm"'\'' >> $HOME/.profile # Linux'
-    echo 'echo '\''export ZVM_PATH="$HOME/Library/zvm"'\'' >> $HOME/.profile # macOS'
-    echo 'echo '\''export PATH="$PATH:$ZVM_PATH/bin"'\'' >> $HOME/.profile'
+    echo -e "Installing $1 in $install_dir"
+    mkdir -p "$install_dir"
+    tar -xf "zvm.zip" -C "$install_dir"
+    ln -sf "$install_dir/zvm" "$bin_dir"
+    rm "zvm.zip"
 
-    echo "Make sure \$HOME/.local/bin is in your PATH on Linux."
-    echo "Make sure \$HOME/bin is in your PATH on macOS."
+    post_install_setup
 
-    echo "Run 'zvm i master' to install Zig"
-fi
+}
 
-echo
+main() {
+    case "$ARCH" in
+    "aarch64")
+        ARCH="arm64"
+        ;;
+    "x86_64")
+        ARCH="amd64"
+        ;;
+    esac
+
+    if [ "$OS" != "Darwin" ] && [ "$OS" != "Linux" ]; then
+        echo "$OS-$ARCH not supported. If you are on Windows, please use install.ps1"
+        return 1
+    fi
+
+    echo "Installing zvm-${OS,,}-$ARCH.tar"
+    install_zvm "zvm-${OS,,}-$ARCH.tar"
+
+}
+
+main

--- a/install.sh
+++ b/install.sh
@@ -104,12 +104,16 @@ install_zvm() {
         return 1
     fi
 
-    download_file "https://github.com/tristanisham/zvm/releases/latest/download/$1" "zvm.zip"
+    if ! download_file "https://github.com/tristanisham/zvm/releases/latest/download/$1" "zvm.zip"; then
+        echo "Error: Failed to download zvm from https://github.com/tristanisham/zvm/releases/latest/download/$1"
+        exit 1
+    fi
 
     echo -e "Installing $1 in $install_dir"
     mkdir -p "$install_dir"
     tar -xf "zvm.zip" -C "$install_dir"
-    ln -sf "$install_dir/zvm" "$bin_dir"
+    mkdir -p "$bin_dir"
+    ln -sf "$install_dir/zvm" "$bin_dir/zvm"
     rm "zvm.zip"
 
     post_install_setup

--- a/install.sh
+++ b/install.sh
@@ -135,8 +135,10 @@ main() {
         return 1
     fi
 
-    echo "Installing zvm-${OS,,}-$ARCH.tar"
-    install_zvm "zvm-${OS,,}-$ARCH.tar"
+    local os_lower
+    os_lower=$(uname -s | tr '[:upper:]' '[:lower:]')
+    echo "Installing zvm-${os_lower}-$ARCH.tar"
+    install_zvm "zvm-${os_lower}-$ARCH.tar"
 
 }
 

--- a/install.sh
+++ b/install.sh
@@ -85,19 +85,21 @@ if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM" == "screen" |
     NC='\033[0m'       # No Color
 
     echo -e "${GREEN}echo${NC} ${RED}\"# ZVM\"${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
-    echo -e "${GREEN}echo${NC} ${RED}'export ZVM_INSTALL=\"\$HOME/.zvm/self\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
-    echo -e "${GREEN}echo${NC} ${RED}'export PATH=\"\$PATH:\$HOME/.zvm/bin\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
-    echo -e "${GREEN}echo${NC} ${RED}'export PATH=\"\$PATH:\$ZVM_INSTALL/\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC}"
+    echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$XDG_DATA_HOME/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# Linux${NC}"
+    echo -e "${GREEN}echo${NC} ${RED}'export ZVM_PATH=\"\$HOME/Library/zvm\"'${NC} ${GREEN}>>${NC} ${BLUE}\$HOME/.profile${NC} ${GREEN}# macOS${NC}"
 
-    echo -e "Run '${GREEN}source ~/.profile${NC}' to start using ZVM in this shell!"
+    echo "Make sure ${RED}\$HOME/.local/bin${NC} is in your PATH on Linux."
+    echo "Make sure ${RED}\$HOME/bin${NC} is in your PATH on macOS."
+
     echo "Run 'zvm i master' to install Zig"
 else
     echo 'echo "# ZVM" >> $HOME/.profile'
-    echo 'echo '\''export ZVM_INSTALL="$HOME/.zvm/self"'\'' >> $HOME/.profile'
-    echo 'echo '\''export PATH="$PATH:$HOME/.zvm/bin"'\'' >> $HOME/.profile'
-    echo 'echo '\''export PATH="$PATH:$ZVM_INSTALL/"'\'' >> $HOME/.profile'
+    echo 'echo '\''export ZVM_PATH="$XDG_DATA_HOME/zvm"'\'' >> $HOME/.profile # Linux'
+    echo 'echo '\''export ZVM_PATH="$HOME/Library/zvm"'\'' >> $HOME/.profile # macOS'
 
-    echo "Run 'source ~/.profile' to start using ZVM in this shell!"
+    echo "Make sure \$HOME/.local/bin is in your PATH on Linux."
+    echo "Make sure \$HOME/bin is in your PATH on macOS."
+
     echo "Run 'zvm i master' to install Zig"
 fi
 


### PR DESCRIPTION
This PR makes changes to the install.sh script so that zvm follows the XDG Specification for Linux and MacOS. Following the new installation paths.

The PR also adds CI/CD test to make sure that the changes work on the following distros
- ubuntu
- fedora
- arch linux
- macos-latest

The install.sh now only is responsible for MacOS/Linux. On windows it throws error and suggests user to use `install.ps1` script

**Linux**:
- Installation path: `"$XDG_DATA_HOME/zvm/self"`
- Binary Path: `"$HOME/.local/bin"`

**MacOS**:
- Installation path: `"$HOME/Library/zvm/self"`
- Binary Path: `"$HOME/bin"`

`zvm` binary gets symlink to Binary Path on both OSes. `"$HOME/.local/bin"` [should already be on path for most Linux distros](https://unix.stackexchange.com/questions/316765/which-distributions-have-home-local-bin-in-path) and for MacOS  `"$HOME/bin"` should be on path as well. This way users don't need to modify the the `.profile` in most cases. 