### PR TITLE
Install zig and zls only if version is not already installed

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -64,10 +64,10 @@ func (z *ZVM) Install(version string, force bool) error {
 						}
 					}
 				}
-				if alreadyInstalled {
-					fmt.Printf("Zig version %s is already installed\n", installedVersion)
-					return nil
-				}
+			}
+			if alreadyInstalled {
+				fmt.Printf("Zig version %s is already installed\n", installedVersion)
+				return nil
 			}
 		}
 	}

--- a/cli/use.go
+++ b/cli/use.go
@@ -22,7 +22,7 @@ func (z *ZVM) Use(ver string) error {
 
 			fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", ver)
 			if getConfirmation() {
-				if err = z.Install(ver); err != nil {
+				if err = z.Install(ver, false); err != nil {
 					return err
 				}
 			} else {

--- a/main.go
+++ b/main.go
@@ -66,6 +66,10 @@ var zvmApp = &opts.App{
 					// Aliases: []string{"z"},
 					Usage: "install ZLS",
 				},
+				&opts.BoolFlag{
+					Name:  "force",
+					Usage: "force installation even if the version is already installed",
+				},
 			},
 			Description: "To install the latest version, use `master`",
 			Args:        true,
@@ -91,15 +95,16 @@ var zvmApp = &opts.App{
 				// 		return err
 				// 	}
 				// }
+				force := ctx.Bool("force")
 
 				// Install Zig
-				if err := zvm.Install(req.Package); err != nil {
+				if err := zvm.Install(req.Package, force); err != nil {
 					return err
 				}
 
 				// Install ZLS (if requested)
 				if ctx.Bool("zls") {
-					if err := zvm.InstallZls(req.Package); err != nil {
+					if err := zvm.InstallZls(req.Package, force); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
This PR should address [this issue](https://github.com/tristanisham/zvm/issues/76). The idea is if we have a none master version we simply check if the provided version is already installed. If we do have the version master we always check only what the latest version for master is and check if the local installation matches that.

This builds on my go fmt + gpls PR so there are some more changes then. I would like. We should probably adresse the other PR first before really talking about this one.