### PR TITLE
Use ZLS release worker for selecting builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ pass the `--zls` flag with `zvm i`. For example:
 zvm i --zls master
 ```
 
+#### Select ZLS compatibility mode
+
+By default, ZVM will install a ZLS build, which can be used with the given Zig version,
+but may not be able to build ZLS from source.
+If you want to use a ZLS build, which can be built using the selected Zig version, pass
+the `--full` flag with `zvm i --zls`. For example:
+
+```sh
+zvm i --zls --full master
+```
+
+> [!IMPORTANT]
+> This does not apply to tagged releases, e.g.: `0.13.0`
+
 ## Switch between installed Zig versions
 
 ```sh

--- a/cli/error.go
+++ b/cli/error.go
@@ -18,4 +18,5 @@ var (
 	ErrInvalidInput          = errors.New("invalid input")
 	// ErrDownloadFail is an an error when fetching Zig, or constructing a target URL to fetch Zig.
 	ErrDownloadFail = errors.New("failed to download Zig")
+	ErrNoZlsVersion = errors.New("zls release worker returned error")
 )

--- a/cli/error.go
+++ b/cli/error.go
@@ -17,6 +17,8 @@ var (
 	ErrInvalidVersionMap     = errors.New("invalid version map format")
 	ErrInvalidInput          = errors.New("invalid input")
 	// ErrDownloadFail is an an error when fetching Zig, or constructing a target URL to fetch Zig.
-	ErrDownloadFail = errors.New("failed to download Zig")
-	ErrNoZlsVersion = errors.New("zls release worker returned error")
+	ErrDownloadFail       = errors.New("failed to download Zig")
+	ErrNoZlsVersion       = errors.New("zls release worker returned error")
+	ErrMissingVersionInfo = errors.New("version info not found")
+	ErrMissingShasum      = errors.New("shasum not found")
 )

--- a/cli/install.go
+++ b/cli/install.go
@@ -81,7 +81,7 @@ func (z *ZVM) Install(version string, force bool) error {
 
 	log.Debug("tarPath", "url", tarPath)
 
-	tarResp, err := reqZigDownload(tarPath)
+	tarResp, err := requestDownload(tarPath)
 	if err != nil {
 		return err
 	}
@@ -197,8 +197,8 @@ func (z *ZVM) Install(version string, force bool) error {
 	return nil
 }
 
-// reqZigDownload HTTP requests Zig downloads from the official site and mirrors
-func reqZigDownload(tarURL string) (*http.Response, error) {
+// requestDownload HTTP requests Zig downloads from the official site and mirrors
+func requestDownload(tarURL string) (*http.Response, error) {
 	log.Debug("requestWithMirror", "tarURL", tarURL)
 
 	tarResp, err := attemptDownload(tarURL)
@@ -395,7 +395,7 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 
 	log.Debug("tarPath", "url", tarPath)
 
-	tarResp, err := reqZigDownload(tarPath)
+	tarResp, err := requestDownload(tarPath)
 	if err != nil {
 		return err
 	}
@@ -418,14 +418,14 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 
 	var clr_opt_ver_str string
 	if z.Settings.UseColor {
-		clr_opt_ver_str = clr.Green(zigVersion)
+		clr_opt_ver_str = clr.Green(zlsVersion)
 	} else {
-		clr_opt_ver_str = zigVersion
+		clr_opt_ver_str = zlsVersion
 	}
 
 	pbar := progressbar.DefaultBytes(
 		int64(tarResp.ContentLength),
-		fmt.Sprintf("Downloading %s:", clr_opt_ver_str),
+		fmt.Sprintf("Downloading ZLS %s:", clr_opt_ver_str),
 	)
 
 	hash := sha256.New()

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -70,24 +70,34 @@ func (z *ZVM) GetInstalledVersions() ([]string, error) {
 }
 
 func (z ZVM) ListRemoteAvailable() error {
-	versions, err := z.fetchVersionMap()
+	zigVersions, err := z.fetchVersionMap()
 	if err != nil {
 		return err
 	}
 
-	options := make([]string, 0, len(versions))
+	zlsVersions, err := z.fetchZlsTaggedVersionMap()
+	if err != nil {
+		return err
+	}
 
-	for key := range versions {
+	options := make([]string, 0, len(zigVersions))
+
+	// add 'v' prefix for sorting.
+	for key := range zigVersions {
 		options = append(options, "v"+key)
 	}
 
 	semver.Sort(options)
 	slices.Reverse(options)
 
-	// Remove "v" prefix to maintain consistency with zig versioning
+	// remove "v" prefix to maintain consistency with zig versioning.
 	finalList := options[:0]
 	for _, version := range options {
-		finalList = append(finalList, version[1:])
+		stripped := version[1:]
+		if _, ok := zlsVersions[stripped]; ok {
+			stripped += "\t(tagged zls)"
+		}
+		finalList = append(finalList, stripped)
 	}
 
 	fmt.Println(strings.Join(finalList, "\n"))

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -60,7 +60,7 @@ func (z *ZVM) GetInstalledVersions() ([]string, error) {
 	versions := make([]string, 0, len(dir))
 	for _, key := range dir {
 		switch key.Name() {
-		case "settings.json", "bin", "versions.json", "self":
+		case "settings.json", "bin", "versions.json", "versions-zls.json", "self":
 			continue
 		default:
 			versions = append(versions, key.Name())

--- a/cli/settings.go
+++ b/cli/settings.go
@@ -16,10 +16,11 @@ import (
 )
 
 type Settings struct {
-	path               string
-	VersionMapUrl      string `json:"versionMapUrl,omitempty"`
-	UseColor           bool   `json:"useColor"`
-	AlwaysForceInstall bool   `json:"alwaysForceInstall"`
+	path                    string
+	VersionMapUrl           string `json:"versionMapUrl,omitempty"`
+	ZlsReleaseWorkerBaseUrl string `json:"zlsReleaseWorkerBaseUrl,omitempty"`
+	UseColor                bool   `json:"useColor"`
+	AlwaysForceInstall      bool   `json:"alwaysForceInstall"`
 }
 
 func (s *Settings) ToggleColor() {
@@ -38,6 +39,15 @@ func (s *Settings) ToggleColor() {
 
 func (s *Settings) ResetVersionMap() error {
 	s.VersionMapUrl = "https://ziglang.org/download/index.json"
+	if err := s.save(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Settings) ResetZlsReleaseWorkerBaseUrl() error {
+	s.ZlsReleaseWorkerBaseUrl = "https://releases.zigtools.org"
 	if err := s.save(); err != nil {
 		return err
 	}
@@ -79,6 +89,21 @@ func (s *Settings) SetVersionMapUrl(versionMapUrl string) error {
 	}
 
 	log.Debug("set version map url", "url", s.VersionMapUrl)
+
+	return nil
+}
+
+func (s *Settings) SetZlsReleaseWorkerBaseUrl(versionMapUrl string) error {
+	if err := isValidWebURL(versionMapUrl); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidVersionMap, err)
+	}
+
+	s.ZlsReleaseWorkerBaseUrl = versionMapUrl
+	if err := s.save(); err != nil {
+		return err
+	}
+
+	log.Debug("set zls release worker base url", "url", s.ZlsReleaseWorkerBaseUrl)
 
 	return nil
 }

--- a/cli/use.go
+++ b/cli/use.go
@@ -50,7 +50,7 @@ func (z *ZVM) setBin(ver string) error {
 	// CreateFile C:\Users\gs\.zvm\bin: The system cannot find the file specified.
 	//
 	// which leads to evaluation of the else case (line 59) and to an early return
-	// therefore the the inital symbolic link is never created.
+	// therefore the the initial symbolic link is never created.
 	if stat != nil {
 		if err == nil {
 			log.Debugf("Removing old %s", bin_dir)

--- a/cli/version.go
+++ b/cli/version.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (z *ZVM) fetchVersionMap() (zigVersionMap, error) {
-	log.Debug("inital VMU", "url", z.Settings.VersionMapUrl)
+	log.Debug("initial VMU", "url", z.Settings.VersionMapUrl)
 
 	if err := z.loadSettings(); err != nil {
 		log.Warnf("could not load version map from settings: %q", err)
@@ -75,7 +75,7 @@ func (z *ZVM) fetchVersionMap() (zigVersionMap, error) {
 
 // note: the zls release-worker uses the same index format as zig, but without the latest master entry.
 func (z *ZVM) fetchZlsTaggedVersionMap() (zigVersionMap, error) {
-	log.Debug("inital ZRW", "url", z.Settings.ZlsReleaseWorkerBaseUrl)
+	log.Debug("initial ZRW","func", "fetchZlsTaggedVersionMap", "url", z.Settings.ZlsReleaseWorkerBaseUrl)
 
 	if err := z.loadSettings(); err != nil {
 		log.Warnf("could not load zls release worker base url from settings: %q", err)
@@ -131,7 +131,7 @@ func (z *ZVM) fetchZlsTaggedVersionMap() (zigVersionMap, error) {
 // note: the zls release-worker uses the same index format as zig, but without the latest master entry.
 // this function does not write the result to a file.
 func (z *ZVM) fetchZlsVersionByZigVersion(version string, compatMode string) (zigVersion, error) {
-	log.Debug("inital ZRW", "url", z.Settings.ZlsReleaseWorkerBaseUrl)
+	log.Debug("initial ZRW","func", "fetchZlsVersionByZigVersion", "url", z.Settings.ZlsReleaseWorkerBaseUrl)
 
 	if err := z.loadSettings(); err != nil {
 		log.Warnf("could not load zls release worker base url from settings: %q", err)

--- a/main.go
+++ b/main.go
@@ -216,6 +216,28 @@ var zvmApp = &opts.App{
 				return nil
 			},
 		},
+		{
+			Name:  "zrw",
+			Usage: "set ZVM's URL for custom Zls Release Workers",
+			Args:  true,
+			Action: func(ctx *opts.Context) error {
+				url := ctx.Args().First()
+				log.Debug("user passed zrw", "url", url)
+
+				switch url {
+				case "default":
+					return zvm.Settings.ResetZlsReleaseWorkerBaseUrl()
+
+				default:
+					if err := zvm.Settings.SetZlsReleaseWorkerBaseUrl(url); err != nil {
+						log.Info("Run `zvm zrw default` to reset your release worker.")
+						return err
+					}
+				}
+
+				return nil
+			},
+		},
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ var zvmApp = &opts.App{
 					Aliases: []string{"f"},
 					Usage:   "force installation even if the version is already installed",
 				},
+				&opts.BoolFlag{
+					Name:  "full",
+					Usage: "use the 'full' zls compatibility mode",
+				},
 			},
 			Description: "To install the latest version, use `master`",
 			Args:        true,
@@ -91,14 +95,20 @@ var zvmApp = &opts.App{
 					force = ctx.Bool("force")
 				}
 
+				zlsCompat := "only-runtime"
+				if ctx.Bool("full") {
+					zlsCompat = "full"
+				}
+
 				// Install Zig
-				if err := zvm.Install(req.Package, force); err != nil {
+				err := zvm.Install(req.Package, force)
+				if err != nil {
 					return err
 				}
 
 				// Install ZLS (if requested)
 				if ctx.Bool("zls") {
-					if err := zvm.InstallZls(req.Package, force); err != nil {
+					if err := zvm.InstallZls(req.Package, zlsCompat, force); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
This PR refactors the ZLS installation process to use the recently made-available [release-worker](https://github.com/zigtools/release-worker) by the maintainers of ZLS.

It has two APIs:
- for fetching a version index for *tagged* builds (e.g. `0.12.0`, `0.13.0`) -> [index](https://github.com/zigtools/release-worker?tab=readme-ov-file#v1zlsindexjson)
- for fetching a ZLS build for a given Zig build -> [select-version](https://github.com/zigtools/release-worker?tab=readme-ov-file#v1zlsselect-version)

The installation process is now as follows:
- Determine currently installed Zig version (by executing `zig version` on the requested version by the user)
- Use the resulting version to select a ZLS build:
  - We first check the version index for the tagged releases
  - Otherwise use the `select-version` API to fetch a valid ZLS build
- We extract the following information:
  - ZLS build `version`
  - `tarball` path/uri
  - `shasum`
- The rest of the process is very similar to the Zig installation process, except for the linking at the end

Other changes: 
- For the `install --zls` command, the `--full` flag has been added. By default it uses `only-runtime`. More information here: https://github.com/zigtools/release-worker?tab=readme-ov-file#query-parameters
- The `ls --all` command was changed to also show whether there is a *tagged* ZLS build available for the respective Zig version.
- Whenever the ZLS tagged version index is fetched, the JSON is saved in the `versions-zls.json` file. This does not apply to the `select-version` API.
- A `zrw` command (similar to `vmu`) has been added to change the base url of the release worker. By default the "official" instance at `https://releases.zigtools.org` is used.

*Tested on Ubuntu 22.04.5 LTS and Windows 11.*

related #97 
related #68 