### PR TITLE
feat: zsh detection for installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,7 @@ if [ -n "$TARGET_FILE" ]; then
     echo "Run 'zvm i master' to install Zig"
 else
     echo
-    echo "No ~/.profile or ~/.bashrc file found."
+    echo "No ~/.profile, ~/.bashrc, ~/.zshenv or ~/.zshrc file found."
     echo "Run the following commands to set up ZVM environment variables in this session or append them to your shell's startup script:"
     echo
     if [[ "$TERM" == "xterm"* || "$TERM" == "screen"* || "$TERM" == "tmux"* ]]; then

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,10 @@ if [ -f "$HOME/.profile" ]; then
     TARGET_FILE="$HOME/.profile"
 elif [ -f "$HOME/.bashrc" ]; then
     TARGET_FILE="$HOME/.bashrc"
+elif [ -f "$HOME/.zshenv" ]; then
+    TARGET_FILE="$HOME/.zshenv"
+elif [ -f "$HOME/.zshrc" ]; then
+    TARGET_FILE="$HOME/.zshrc"
 else
     TARGET_FILE=""
 fi


### PR DESCRIPTION
Add's extra targets for installation, keeping the old behavior but extending the preference list. The preference list goes as:

* `.profile`
* `.bashrc`
* `.zshenv`
* `.zshrc`

I also added this to the debug message if any of them were not picked up.

---

Improvements that could be made:
* Some people might be using `zsh` but still have a `.bashrc` lying around, in which case it gets injected into the wrong file. You could considering detecting the shell environment using `$SHELL` (`/bin/zsh`, `/bin/bash`), but this can quickly get quite cumbersome for non-default setup.