### PR TITLE
skip flag parsing with zvm run

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ var zvmApp = &opts.Command{
 			Name:  "run",
 			Usage: "run a command with the given Zig version",
 			// Args:  true,
+			SkipFlagParsing: true,
 			Action: func(ctx context.Context, cmd *opts.Command) error {
 				versionArg := strings.TrimPrefix(cmd.Args().First(), "v")
 				cmds := cmd.Args().Tail()


### PR DESCRIPTION
Hello,

currently `zvm run` can't be used with a zig command that requires flags, for example `zvm run 0.13.0 build test --summary all` fails because urfave/cli will try to parse the `--summary` flag; the command fails with this error:

    Incorrect Usage: flag provided but not defined: -summary

    2025/03/01 22:13:59 ERRO flag provided but not defined: -summary

This PR fixes this by telling urfave/cli to skip flag parsing in `zvm run`.