### PR TITLE
add 'no-sha' flag as temporary fix

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -55,7 +55,7 @@ func (z *ZVM) Run(version string, cmd []string) error {
 		fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", version)
 
 		if getConfirmation() {
-			if err = z.Install(version, false); err != nil {
+			if err = z.Install(version, false, true); err != nil {
 				return err
 			}
 			return z.runZig(version, cmd)

--- a/cli/use.go
+++ b/cli/use.go
@@ -22,7 +22,7 @@ func (z *ZVM) Use(ver string) error {
 
 			fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", ver)
 			if getConfirmation() {
-				if err = z.Install(ver, false); err != nil {
+				if err = z.Install(ver, false, true); err != nil {
 					return err
 				}
 			} else {

--- a/main.go
+++ b/main.go
@@ -73,6 +73,10 @@ var zvmApp = &opts.Command{
 					Usage:   "force installation even if the version is already installed",
 				},
 				&opts.BoolFlag{
+					Name:    "no-sha",
+					Usage:   "skip SHA256 verification of the downloaded Zig binary",
+				},
+				&opts.BoolFlag{
 					Name:  "full",
 					Usage: "use the 'full' zls compatibility mode",
 				},
@@ -96,13 +100,15 @@ var zvmApp = &opts.Command{
 					force = cmd.Bool("force")
 				}
 
+                var sha = !cmd.Bool("no-sha")
+
 				zlsCompat := "only-runtime"
 				if cmd.Bool("full") {
 					zlsCompat = "full"
 				}
 
 				// Install Zig
-				err := zvm.Install(req.Package, force)
+				err := zvm.Install(req.Package, force, sha)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
tested the download with no shasum check with 0.12.1, and it worked successfully. Not that I don't think someone with a stronger grasp on go couldn't work out a more elegant solution.