### PR TITLE
Add check for 32-bit arch as there is no release for it.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -96,4 +96,10 @@ function Install-ZVM {
 
 
 $PROCESSOR_ARCH = $env:PROCESSOR_ARCHITECTURE.ToLower()
+if ($PROCESSOR_ARCH -eq "x86") {
+  Write-Output "Install Failed - ZVM requires a 64-bit environment."
+  Write-Output "Please ensure that you are running the 64-bit version of PowerShell or that your system is 64-bit.`n"
+  exit 1
+}
+
 Install-ZVM "zvm-windows-$PROCESSOR_ARCH.zip"


### PR DESCRIPTION
I was running powershell x86 and the install script failed because the curl tried to fetch a zvm-windows-x86.zip that does not exist, and then I saw that there are no releases for 32-bit systems which make sense, but there is no check implemented yet.