### PR TITLE
Add support for installing dev versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ zvm i --force master
 You can also enable the old behavior by setting the new `alwaysForceInstall`
 field to `true` in `~/.zvm/settings.json`.
 
+### Skip Shasum Check
+
+You can skip the shasum verification during installation using the `--skip-shasum` or `-s` flag. This is required for installing development versions.
+
+```sh
+zvm i --skip-shasum 0.16.0-dev.1334+06d08daba
+```
+
+This flag also works for normal versions if you want to skip the verification step.
+
 ### Install ZLS with ZVM
 
 You can now install ZLS with your Zig download! To install ZLS with ZVM, simply

--- a/cli/run.go
+++ b/cli/run.go
@@ -55,7 +55,7 @@ func (z *ZVM) Run(version string, cmd []string) error {
 		fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", version)
 
 		if getConfirmation() {
-			if err = z.Install(version, false, true); err != nil {
+			if err = z.Install(version, false, false, true); err != nil {
 				return err
 			}
 			return z.runZig(version, cmd)

--- a/cli/use.go
+++ b/cli/use.go
@@ -23,7 +23,7 @@ func (z *ZVM) Use(ver string) error {
 
 			fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", ver)
 			if getConfirmation() {
-				if err = z.Install(ver, false, true); err != nil {
+				if err = z.Install(ver, false, false, true); err != nil {
 					return err
 				}
 			} else {

--- a/main.go
+++ b/main.go
@@ -101,6 +101,11 @@ var zvmApp = &opts.Command{
 					force = cmd.Bool("force")
 				}
 
+				// Validate development versions require --force flag
+				if cli.isDevelopmentVersion(req.Package) && !force {
+					return errors.New("development versions require the --force flag to install. Use: zvm i " + req.Package + " --force")
+				}
+
 				zlsCompat := "only-runtime"
 				if cmd.Bool("full") {
 					zlsCompat = "full"

--- a/main.go
+++ b/main.go
@@ -74,6 +74,11 @@ var zvmApp = &opts.Command{
 					Usage:   "force installation even if the version is already installed",
 				},
 				&opts.BoolFlag{
+					Name:    "skip-shasum",
+					Aliases: []string{"s"},
+					Usage:   "skip shasum check during installation",
+				},
+				&opts.BoolFlag{
 					Name:  "full",
 					Usage: "use the 'full' zls compatibility mode",
 				},
@@ -96,14 +101,15 @@ var zvmApp = &opts.Command{
 				req.Version = strings.TrimPrefix(req.Version, "v")
 
 				force := zvm.Settings.AlwaysForceInstall
+				skipShasum := cmd.Bool("skip-shasum")
 
 				if cmd.Bool("force") {
 					force = cmd.Bool("force")
 				}
 
-				// Validate development versions require --force flag
-				if cli.IsDevelopmentVersion(req.Package) && !force {
-					return errors.New("development versions require the --force flag to install. Use: zvm i " + req.Package + " --force")
+				// Validate development versions require --skip-shasum flag
+				if cli.IsDevelopmentVersion(req.Package) && !skipShasum {
+					return errors.New("development versions require the --skip-shasum flag to install. Use: zvm i " + req.Package + " --skip-shasum")
 				}
 
 				zlsCompat := "only-runtime"
@@ -112,14 +118,14 @@ var zvmApp = &opts.Command{
 				}
 
 				// Install Zig
-				err := zvm.Install(req.Package, force, !cmd.Bool("nomirror"))
+				err := zvm.Install(req.Package, force, skipShasum, !cmd.Bool("nomirror"))
 				if err != nil {
 					return err
 				}
 
 				// Install ZLS (if requested)
 				if cmd.Bool("zls") {
-					if err := zvm.InstallZls(req.Package, zlsCompat, force); err != nil {
+					if err := zvm.InstallZls(req.Package, zlsCompat, force, skipShasum); err != nil {
 						return err
 					}
 				}

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ var zvmApp = &opts.Command{
 				}
 
 				// Validate development versions require --force flag
-				if cli.isDevelopmentVersion(req.Package) && !force {
+				if cli.IsDevelopmentVersion(req.Package) && !force {
 					return errors.New("development versions require the --force flag to install. Use: zvm i " + req.Package + " --force")
 				}
 


### PR DESCRIPTION
This PR make installing a specific dev version possible by bypassing the version map (fixes https://github.com/tristanisham/zvm/issues/23#issuecomment-1815403869).

To install a specific dev version, run `zvm i 0.16.0-dev.1334+06d08daba --force`. (the force flag is reused here to make sure bypassing the version map is intended).

I have to admit that this code is written by Claude, as I'm not experienced with Go, but I have tested it locally on my linux machine and it works.