### PR TITLE
Fix listing versions without color

### DIFF
--- a/cli/ls.go
+++ b/cli/ls.go
@@ -52,7 +52,7 @@ func (z *ZVM) ListVersions() error {
 				// Should just check bin for used version
 				fmt.Println(clr.Green(key))
 			} else {
-				fmt.Printf("%s [x]\n", key)
+				fmt.Println(key + " [x]")
 			}
 		} else {
 			fmt.Println(key)


### PR DESCRIPTION
When color is off current version is shown with " [x]" but that line was missing new line character at the end. This fixes output of `zvm ls`

Before this fix:

```sh
$ zvm ls
0.14.1
0.15.1
0.15.2 [x]master
```

After:

```sh
$ zvm ls
0.14.1
0.15.1
0.15.2 [x]
master
```
