### PR TITLE
Fixed issue with incorrect unarchive path for Windows install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -92,8 +92,7 @@ function Install-ZVM {
         if ($env:PATH -notcontains ";${ZVMBin}") {
             $env:PATH = "${env:Path};${ZVMBin}"
         }
-    }
-    else {
+    } else {
         Write-Output "Skipping environment variable setup due to --no-env flag.`n"
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -31,7 +31,7 @@ function Install-ZVM {
     try {
         $lastProgressPreference = $global:ProgressPreference
         $global:ProgressPreference = 'SilentlyContinue';
-        Expand-Archive "$ZipPath" "$ZVMSelf" -Force
+        Expand-Archive "$ZipPath" "$ZVMSelf\$UnzippedPath" -Force
         $global:ProgressPreference = $lastProgressPreference
         if (!(Test-Path "${ZVMSelf}\$UnzippedPath\zvm.exe")) {
             throw "The file '${ZVMSelf}\$UnzippedPath\zvm.exe' does not exist. Download is corrupt / Antivirus intercepted?`n"
@@ -92,7 +92,8 @@ function Install-ZVM {
         if ($env:PATH -notcontains ";${ZVMBin}") {
             $env:PATH = "${env:Path};${ZVMBin}"
         }
-    } else {
+    }
+    else {
         Write-Output "Skipping environment variable setup due to --no-env flag.`n"
     }
 
@@ -103,9 +104,9 @@ function Install-ZVM {
 $PROCESSOR_ARCH = $env:PROCESSOR_ARCHITECTURE.ToLower()
 
 if ($PROCESSOR_ARCH -eq "x86") {
-  Write-Output "Install Failed - ZVM requires a 64-bit environment."
-  Write-Output "Please ensure that you are running the 64-bit version of PowerShell or that your system is 64-bit.`n"
-  exit 1
+    Write-Output "Install Failed - ZVM requires a 64-bit environment."
+    Write-Output "Please ensure that you are running the 64-bit version of PowerShell or that your system is 64-bit.`n"
+    exit 1
 }
 
 # Parse --no-env flag if present


### PR DESCRIPTION
This error occurs while installing the latest version of ZVM. Looks like archiving logic was changed to archive the binary itself without a target folder.

<img width="1822" height="460" alt="image" src="https://github.com/user-attachments/assets/3e1b4ac2-192a-4723-9794-f7d1a6909d9e" />
