### PR TITLE
fix(install.ps1): extract directly to self dir and clarify Windows Defender error

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -30,7 +30,7 @@ function Install-ZVM {
     try {
         $lastProgressPreference = $global:ProgressPreference
         $global:ProgressPreference = 'SilentlyContinue';
-        Remove-Item "${ZVMSelf}\zvm.exe" -ErrorAction SilentlyContinue
+        Remove-Item "${ZVMSelf}\zvm.exe" -Force -ErrorAction SilentlyContinue
         Expand-Archive "$ZipPath" "$ZVMSelf" -Force
         Unblock-File "${ZVMSelf}\zvm.exe" -ErrorAction SilentlyContinue
         $global:ProgressPreference = $lastProgressPreference

--- a/install.ps1
+++ b/install.ps1
@@ -32,6 +32,7 @@ function Install-ZVM {
         $global:ProgressPreference = 'SilentlyContinue';
         Remove-Item "${ZVMSelf}\zvm.exe" -ErrorAction SilentlyContinue
         Expand-Archive "$ZipPath" "$ZVMSelf" -Force
+        Unblock-File "${ZVMSelf}\zvm.exe" -ErrorAction SilentlyContinue
         $global:ProgressPreference = $lastProgressPreference
         if (!(Test-Path "${ZVMSelf}\zvm.exe")) {
             throw "The file '${ZVMSelf}\zvm.exe' does not exist.`nLikely cause: Windows Defender quarantined it.`nFix: Add an exclusion for '$ZVMRoot' in Windows Security > Virus & threat protection > Exclusions, then re-run the installer.`n"

--- a/install.ps1
+++ b/install.ps1
@@ -27,14 +27,14 @@ function Install-ZVM {
         Write-Output "The file '$ZipPath' does not exist. Did an antivirus delete it?`n"
         exit 1
     }
-    $UnzippedPath = $Target.Substring(0, $Target.Length - 4)
     try {
         $lastProgressPreference = $global:ProgressPreference
         $global:ProgressPreference = 'SilentlyContinue';
-        Expand-Archive "$ZipPath" "$ZVMSelf\$UnzippedPath" -Force
+        Remove-Item "${ZVMSelf}\zvm.exe" -ErrorAction SilentlyContinue
+        Expand-Archive "$ZipPath" "$ZVMSelf" -Force
         $global:ProgressPreference = $lastProgressPreference
-        if (!(Test-Path "${ZVMSelf}\$UnzippedPath\zvm.exe")) {
-            throw "The file '${ZVMSelf}\$UnzippedPath\zvm.exe' does not exist. Download is corrupt / Antivirus intercepted?`n"
+        if (!(Test-Path "${ZVMSelf}\zvm.exe")) {
+            throw "The file '${ZVMSelf}\zvm.exe' does not exist.`nLikely cause: Windows Defender quarantined it.`nFix: Add an exclusion for '$ZVMRoot' in Windows Security > Virus & threat protection > Exclusions, then re-run the installer.`n"
         }
     }
     catch {
@@ -42,11 +42,7 @@ function Install-ZVM {
         Write-Error $_
         exit 1
     }
-    Remove-Item "${ZVMSelf}\zvm.exe" -ErrorAction SilentlyContinue
-    Move-Item "${ZVMSelf}\$UnzippedPath\zvm.exe" "${ZVMSelf}\zvm.exe" -Force
-
-    Remove-Item "${ZVMSelf}\$Target" -Recurse -Force
-    Remove-Item ${ZVMSelf}\$UnzippedPath -Force
+    Remove-Item "${ZVMSelf}\$Target" -Force -ErrorAction SilentlyContinue
 
     $null = "$(& "${ZVMSelf}\zvm.exe")"
     if ($LASTEXITCODE -eq 1073741795) {


### PR DESCRIPTION
Fixes #155

## What's going on

On some Windows setups, the installer fails with "Install Failed - could not unzip" even though the download completes fine. The root cause is how Windows handles security zones. When run via `irm ... | iex`, PowerShell inherits an internet zone context and Windows stamps a `Zone.Identifier` Alternate Data Stream onto anything that session extracts. Defender then aggressively scans and quarantines `zvm.exe` in the gap between extraction and the `Test-Path` check.

Running the script locally via `-File` doesn't trigger this because the session has no internet zone context, which is why it works fine locally but fails online.

## What changed

Three things:

`Unblock-File` after extraction strips the `Zone.Identifier` ADS before Defender gets a chance to act on it. No admin required.

Simplified the extraction to go straight to `~/.zvm/self/` instead of a temp subdirectory. The zip only contains a single `zvm.exe` at root, so the old pattern (extract to subdir, move, delete subdir) was unnecessary.

Improved the error message so if `zvm.exe` is still missing (e.g. exclusion needed), the user gets a clear path to fix it rather than "Download is corrupt / Antivirus intercepted?".

## Checklist

- [x] Tested on Windows (amd64)
- [x] Script runs to completion without errors
- [x] `zvm.exe` ends up in the correct location (`~/.zvm/self/zvm.exe`)
- [x] Environment variable setup (`PATH`, `ZVM_INSTALL`) still works as expected
- [x] `--no-env` flag still works
- [x] No changes to the Go source or any other files

---

*Made with AI assistance (Claude).*