### PR TITLE
Simplify Upgrade() function

### DIFF
--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -92,14 +92,6 @@ func (z *ZVM) Upgrade() error {
 	}
 
 	zvmPath := filepath.Join(zvmInstallDirENV, zvmBinaryName)
-	if err := os.Remove(zvmPath); err != nil {
-		if pathErr, ok := err.(*os.PathError); ok {
-			if os.IsNotExist(pathErr) {
-				log.Debug("Failed to remove file", "path", zvmPath)
-			}
-		}
-	}
-
 	log.Debug("zvmPath", "path", zvmPath)
 
 	newTemp, err := os.MkdirTemp(z.baseDir, "zvm-upgrade-*")
@@ -109,12 +101,12 @@ func (z *ZVM) Upgrade() error {
 	defer os.RemoveAll(newTemp)
 
 	if archive == "zip" {
-	log.Debug("unzip", "from", tempDownload.Name(), "to", newTemp)
+		log.Debug("unzip", "from", tempDownload.Name(), "to", newTemp)
 		if err := unzipSource(tempDownload.Name(), newTemp); err != nil {
 			return errors.Join(ErrFailedUpgrade, err)
 		}
 	} else if archive == "tar" {
-	log.Debug("untar", "from", tempDownload.Name(), "to", newTemp)
+		log.Debug("untar", "from", tempDownload.Name(), "to", newTemp)
 		if err := untar(tempDownload.Name(), newTemp); err != nil {
 			return errors.Join(ErrFailedUpgrade, err)
 		}
@@ -124,7 +116,7 @@ func (z *ZVM) Upgrade() error {
 
 	if err := replaceExe(src, zvmPath); err != nil {
 		log.Warn("This command might break if ZVM is installed outside of ~/.zvm/self/")
-		return fmt.Errorf("upgrade error: %w", err)
+		return errors.Join(ErrFailedUpgrade, err)
 	}
 
 	if err := os.Chmod(zvmPath, 0775); err != nil {
@@ -163,7 +155,7 @@ func replaceExe(from, to string) error {
 		defer to_io.Close()
 
 		if _, err := io.Copy(to_io, from_io); err != nil {
-			return nil
+			return err
 		}
 	}
 

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -46,9 +46,8 @@ func (z *ZVM) Upgrade() error {
 	if !upgradable {
 		fmt.Printf("You are already on the latest release (%s) of ZVM :) \n", clr.Blue(meta.VERSION))
 		os.Exit(0)
-	} else {
-		fmt.Printf("You are on ZVM %s... upgrading to (%s)", meta.VERSION, tagName)
 	}
+	fmt.Printf("You are on ZVM %s... upgrading to (%s)", meta.VERSION, tagName)
 
 	zvmInstallDirENV, err := z.getInstallDir()
 	if err != nil {
@@ -59,13 +58,14 @@ func (z *ZVM) Upgrade() error {
 	zvmBinaryName := "zvm"
 	archive := "tar"
 	if runtime.GOOS == "windows" {
-		archive = "zip"
 		zvmBinaryName = "zvm.exe"
+		archive = "zip"
 	}
 
-	download := fmt.Sprintf("zvm-%s-%s.%s", runtime.GOOS, runtime.GOARCH, archive)
-
-	downloadUrl := fmt.Sprintf("https://github.com/tristanisham/zvm/releases/latest/download/%s", download)
+	downloadUrl := fmt.Sprintf(
+		"https://github.com/tristanisham/zvm/releases/latest/download/zvm-%s-%s.%s",
+		runtime.GOOS, runtime.GOARCH, archive,
+	)
 
 	resp, err := http.Get(downloadUrl)
 	if err != nil {
@@ -73,7 +73,7 @@ func (z *ZVM) Upgrade() error {
 	}
 	defer resp.Body.Close()
 
-	tempDownload, err := os.CreateTemp(z.baseDir, fmt.Sprintf("*.%s", archive))
+	tempDownload, err := os.CreateTemp(z.baseDir, "*."+archive)
 	if err != nil {
 		return err
 	}
@@ -92,9 +92,9 @@ func (z *ZVM) Upgrade() error {
 	}
 
 	zvmPath := filepath.Join(zvmInstallDirENV, zvmBinaryName)
-	if err := os.Remove(filepath.Join(zvmInstallDirENV, zvmBinaryName)); err != nil {
-		if err, ok := err.(*os.PathError); ok {
-			if os.IsNotExist(err) {
+	if err := os.Remove(zvmPath); err != nil {
+		if pathErr, ok := err.(*os.PathError); ok {
+			if os.IsNotExist(pathErr) {
 				log.Debug("Failed to remove file", "path", zvmPath)
 			}
 		}
@@ -104,42 +104,27 @@ func (z *ZVM) Upgrade() error {
 
 	newTemp, err := os.MkdirTemp(z.baseDir, "zvm-upgrade-*")
 	if err != nil {
-		log.Debugf("Failed to create temp direcory: %s", newTemp)
 		return errors.Join(ErrFailedUpgrade, err)
 	}
-
 	defer os.RemoveAll(newTemp)
 
-	if runtime.GOOS == "windows" {
-		log.Debug("unzip", "from", tempDownload.Name(), "to", newTemp)
+	if archive == "zip" {
+	log.Debug("unzip", "from", tempDownload.Name(), "to", newTemp)
 		if err := unzipSource(tempDownload.Name(), newTemp); err != nil {
-			log.Error(err)
-			return err
-		}
-
-		secondaryZVM := fmt.Sprintf("%s.old", zvmPath)
-		log.Debug("SecondaryZVM", "path", secondaryZVM)
-
-		newDownload := filepath.Join(newTemp, fmt.Sprintf("zvm-%s-%s", runtime.GOOS, runtime.GOARCH), zvmBinaryName)
-
-		if err := replaceExe(newDownload, zvmPath); err != nil {
-			log.Warn("This command might break if ZVM is installed outside of ~/.zvm/self/")
-			return fmt.Errorf("upgrade error: %w", err)
-		}
-		// fmt.Println("Run the following to complete your upgrade on Windows.")
-		// fmt.Printf("- Command Prompt:\n\tmove /Y '%s' '%s'\n", secondaryZVM, zvmPath)
-		// fmt.Printf("- Powershell:\n\tMove-Item -Path '%s' -Destination '%s' -Force\n", secondaryZVM, zvmPath)
-
-	} else {
-		if err := untar(tempDownload.Name(), newTemp); err != nil {
-			log.Error(err)
-			return err
-		}
-
-		if err := os.Rename(filepath.Join(newTemp, zvmBinaryName), zvmPath); err != nil {
-			log.Debugf("Failed to rename %s to %s", filepath.Join(newTemp, zvmBinaryName), zvmPath)
 			return errors.Join(ErrFailedUpgrade, err)
 		}
+	} else if archive == "tar" {
+	log.Debug("untar", "from", tempDownload.Name(), "to", newTemp)
+		if err := untar(tempDownload.Name(), newTemp); err != nil {
+			return errors.Join(ErrFailedUpgrade, err)
+		}
+	}
+
+	src := filepath.Join(newTemp, zvmBinaryName)
+
+	if err := replaceExe(src, zvmPath); err != nil {
+		log.Warn("This command might break if ZVM is installed outside of ~/.zvm/self/")
+		return fmt.Errorf("upgrade error: %w", err)
 	}
 
 	if err := os.Chmod(zvmPath, 0775); err != nil {
@@ -150,7 +135,9 @@ func (z *ZVM) Upgrade() error {
 	return nil
 }
 
-// Replaces one file with another on Windows.
+// replaceExe replaces the file at `to` with the file at `from`.
+// On Windows, the existing file is renamed to `.old` rather than deleted,
+// since Windows locks executables that are currently running.
 func replaceExe(from, to string) error {
 	if runtime.GOOS == "windows" {
 		if err := os.Rename(to, fmt.Sprintf("%s.old", to)); err != nil {


### PR DESCRIPTION
This simplifies the OS branching to only zip vs tar. Previously there was a divergence between the path naming convention on windows and linux, causing `zvm upgrade` to fail on windows.

AI Disclosure: 
claude did a first pass of this since i'm not as familiar with Go -- but I subsequently read the entire function and simplified it's initial sloppy change (i had to add back logging, it dropped that for no reason; it also added some pointless helper functions i got rid of as well)