### PR TITLE
77 bug freebsd reporting unsupported system for zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ pass the `--zls` flag with `zvm i`. For example:
 zvm i --zls master
 ```
 
+### Install for a Different Target Platform
+
+If you're on a platform where pre-built Zig binaries aren't available for a
+specific version (e.g., FreeBSD for Zig 0.14.x), you can override the target
+OS and/or architecture to download a compatible build.
+
+Use the `--target-os` and `--target-arch` flags:
+
+```sh
+zvm i --target-os linux --target-arch x86_64 0.14.0
+```
+
+Or set the `ZVM_TARGET_OS` and `ZVM_TARGET_ARCH` environment variables:
+
+```sh
+export ZVM_TARGET_OS=linux
+export ZVM_TARGET_ARCH=x86_64
+zvm i 0.14.0
+```
+
+Both Go-style names (e.g., `darwin`, `amd64`) and Zig-style names (e.g.,
+`macos`, `x86_64`) are accepted.
+
 #### Select ZLS compatibility mode
 
 By default, ZVM will install a ZLS build, which can be used with the given Zig
@@ -419,6 +442,11 @@ Enable or disable colored ZVM output. No value toggles colors.
   checker, just `unset ZVM_SET_CU`.
 - `ZVM_PATH` replaces the default install location for ZVM Set the environment
   variable to the parent directory of where you've placed the `.zvm` directory.
+- `ZVM_TARGET_OS` Override the target operating system for downloads (e.g.,
+  `linux`, `macos`, `windows`, `freebsd`). Useful on platforms where Zig doesn't
+  provide pre-built binaries for a specific version.
+- `ZVM_TARGET_ARCH` Override the target architecture for downloads (e.g.,
+  `x86_64`, `aarch64`, `arm`, `riscv64`).
 - `ZVM_SKIP_TLS_VERIFY` Do you have problems using TLS in your environment?
   Toggle off verifying TLS by setting this environment variable.
   - By default when this is enabled ZVM will print a warning. Set this variable

--- a/README.md
+++ b/README.md
@@ -165,6 +165,25 @@ latest version, use "master".
 zvm i master
 ```
 
+### Version Shorthand
+
+You can use abbreviated version numbers and ZVM will resolve them to the latest
+matching release:
+
+```sh
+zvm i 0.13     # Installs 0.13.0
+zvm i .13      # Same as above — leading dot implies "0."
+zvm i 0.15     # Installs 0.15.2 (latest 0.15.x patch)
+```
+
+Use `stable` to install the latest non-dev release:
+
+```sh
+zvm i stable   # Installs the latest stable release (e.g. 0.16.0)
+```
+
+Version shorthand works with all commands: `install`, `use`, `run`, and `rm`.
+
 ### Force Install
 
 As of `v0.7.6` ZVM will now skip downloading a version if it is already

--- a/cli/install.go
+++ b/cli/install.go
@@ -105,8 +105,9 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 	}
 	defer tarResp.Body.Close()
 
+	_, targetOS := zigStyleSysInfo()
 	var pathEnding string
-	if runtime.GOOS == "windows" {
+	if targetOS == "windows" {
 		pathEnding = "*.zip"
 	} else {
 		pathEnding = "*.tar.xz"
@@ -483,8 +484,9 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 	}
 	defer tarResp.Body.Close()
 
+	_, zlsTargetOS := zigStyleSysInfo()
 	var pathEnding string
-	if runtime.GOOS == "windows" {
+	if zlsTargetOS == "windows" {
 		pathEnding = "*.zip"
 	} else {
 		pathEnding = "*.tar.xz"
@@ -672,9 +674,18 @@ func getVersionShasum(version string, data *map[string]map[string]any) (string, 
 
 // zigStyleSysInfo returns the architecture and operating system strings
 // formatted as expected by Zig's download servers (e.g., "x86_64", "macos").
-func zigStyleSysInfo() (arch string, os string) {
+// It checks ZVM_TARGET_ARCH and ZVM_TARGET_OS environment variables first,
+// falling back to the runtime-detected values.
+func 	zigStyleSysInfo() (arch string, osName string) {
 	arch = runtime.GOARCH
-	os = runtime.GOOS
+	if envArch := os.Getenv("ZVM_TARGET_ARCH"); envArch != "" {
+		arch = envArch
+	}
+
+	osName = runtime.GOOS
+	if envOS := os.Getenv("ZVM_TARGET_OS"); envOS != "" {
+		osName = envOS
+	}
 
 	switch arch {
 	case "amd64":
@@ -687,12 +698,12 @@ func zigStyleSysInfo() (arch string, os string) {
 		arch = "powerpc64le"
 	}
 
-	switch os {
+	switch osName {
 	case "darwin":
-		os = "macos"
+		osName = "macos"
 	}
 
-	return arch, os
+	return arch, osName
 }
 
 // ExtractBundle extracts a compressed bundle (zip, tar.xz) to the specified output directory.

--- a/cli/install.go
+++ b/cli/install.go
@@ -36,20 +36,31 @@ import (
 // Install downloads and installs the specified Zig version.
 // It handles checking for existing installations, verifying checksums,
 // and extracting the downloaded bundle.
-func (z *ZVM) Install(version string, force bool, mirror bool) error {
+func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
 	err := os.MkdirAll(z.baseDir, 0755)
 	if err != nil {
-		return err
+		return version, err
 	}
 	rawVersionStructure, err := z.fetchVersionMap()
 	if err != nil {
-		return err
+		return version, err
+	}
+
+	// Resolve version shorthand (e.g. "0.12" -> "0.12.0", "stable" -> latest release)
+	availableVersions := make([]string, 0, len(rawVersionStructure))
+	for k := range rawVersionStructure {
+		availableVersions = append(availableVersions, k)
+	}
+	if resolved, err := resolveVersionShorthand(version, availableVersions); err == nil && resolved != version {
+		log.Debug("resolved version shorthand", "input", version, "resolved", resolved)
+		fmt.Printf("Resolved %q to %s\n", version, resolved)
+		version = resolved
 	}
 
 	if !force {
 		installedVersions, err := z.GetInstalledVersions()
 		if err != nil {
-			return err
+			return version, err
 		}
 		if slices.Contains(installedVersions, version) {
 			alreadyInstalled := true
@@ -75,7 +86,7 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 			}
 			if alreadyInstalled {
 				fmt.Printf("Zig version %s is already installed\nRerun with the `--force` flag to install anyway\n", installedVersion)
-				return nil
+				return version, nil
 			}
 		}
 	}
@@ -83,9 +94,9 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 	tarPath, err := getTarPath(version, &rawVersionStructure)
 	if err != nil {
 		if errors.Is(err, ErrUnsupportedVersion) {
-			return fmt.Errorf("%s: %q", err, version)
+			return version, fmt.Errorf("%s: %q", err, version)
 		} else {
-			return err
+			return version, err
 		}
 	}
 
@@ -101,7 +112,7 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 	}
 
 	if err != nil {
-		return err
+		return version, err
 	}
 	defer tarResp.Body.Close()
 
@@ -115,7 +126,7 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 
 	tempFile, err := os.CreateTemp(z.baseDir, pathEnding)
 	if err != nil {
-		return err
+		return version, err
 	}
 
 	defer tempFile.Close()
@@ -136,14 +147,14 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 	hash := sha256.New()
 	_, err = io.Copy(io.MultiWriter(tempFile, pbar, hash), tarResp.Body)
 	if err != nil {
-		return err
+		return version, err
 	}
 
 	var shasum string
 
 	shasum, err = getVersionShasum(version, &rawVersionStructure)
 	if err != nil {
-		return err
+		return version, err
 	}
 
 	fmt.Println("Checking shasum...")
@@ -155,7 +166,7 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 			// Why is my sha256 identical on the server and sha256sum,
 			// but not when I download it in ZVM? Oh shit.
 			// It's because it's a compressed download.
-			return fmt.Errorf("shasum for %v does not match expected value", version)
+			return version, fmt.Errorf("shasum for %v does not match expected value", version)
 		}
 		fmt.Println("Shasums match! 🎉")
 	} else {
@@ -166,15 +177,15 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 		fmt.Println("Checking minisign signature...")
 		pubkey, err := minisign.NewPublicKey(z.Settings.MinisignPubKey)
 		if err != nil {
-			return fmt.Errorf("minisign public key decoding failed: %v", err)
+			return version, fmt.Errorf("minisign public key decoding failed: %v", err)
 		}
 		verified, err := pubkey.VerifyFromFile(tempFile.Name(), minisig)
 		if err != nil {
-			return fmt.Errorf("minisign verification failed: %v", err)
+			return version, fmt.Errorf("minisign verification failed: %v", err)
 		}
 
 		if !verified {
-			return fmt.Errorf("minisign signature for %v could not be verified", version)
+			return version, fmt.Errorf("minisign signature for %v could not be verified", version)
 		}
 
 		fmt.Println("Minisign signature verified! 🎉")
@@ -234,7 +245,7 @@ func (z *ZVM) Install(version string, force bool, mirror bool) error {
 	// I figure nobody wants crap just sitting around taking up valuable bytes.
 	_ = z.Clean()
 
-	return nil
+	return version, nil
 }
 
 // attemptMirrorDownload HTTP requests Zig downloads from the community mirrorlist.
@@ -676,7 +687,7 @@ func getVersionShasum(version string, data *map[string]map[string]any) (string, 
 // formatted as expected by Zig's download servers (e.g., "x86_64", "macos").
 // It checks ZVM_TARGET_ARCH and ZVM_TARGET_OS environment variables first,
 // falling back to the runtime-detected values.
-func 	zigStyleSysInfo() (arch string, osName string) {
+func zigStyleSysInfo() (arch string, osName string) {
 	arch = runtime.GOARCH
 	if envArch := os.Getenv("ZVM_TARGET_ARCH"); envArch != "" {
 		arch = envArch

--- a/cli/install_sysinfo_test.go
+++ b/cli/install_sysinfo_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Tristan Isham. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestZigStyleSysInfo(t *testing.T) {
+	// Determine expected defaults from this machine's runtime
+	defaultArch := runtime.GOARCH
+	switch defaultArch {
+	case "amd64":
+		defaultArch = "x86_64"
+	case "arm64":
+		defaultArch = "aarch64"
+	case "loong64":
+		defaultArch = "loongarch64"
+	case "ppc64le":
+		defaultArch = "powerpc64le"
+	}
+
+	defaultOS := runtime.GOOS
+	switch defaultOS {
+	case "darwin":
+		defaultOS = "macos"
+	}
+
+	tests := []struct {
+		name     string
+		envOS    string
+		envArch  string
+		wantOS   string
+		wantArch string
+	}{
+		{
+			name:     "defaults to runtime values",
+			envOS:    "",
+			envArch:  "",
+			wantOS:   defaultOS,
+			wantArch: defaultArch,
+		},
+		{
+			name:     "override OS with zig-style name",
+			envOS:    "linux",
+			envArch:  "",
+			wantOS:   "linux",
+			wantArch: defaultArch,
+		},
+		{
+			name:     "override arch with zig-style name",
+			envOS:    "",
+			envArch:  "x86_64",
+			wantOS:   defaultOS,
+			wantArch: "x86_64",
+		},
+		{
+			name:     "override both with zig-style names",
+			envOS:    "freebsd",
+			envArch:  "aarch64",
+			wantOS:   "freebsd",
+			wantArch: "aarch64",
+		},
+		{
+			name:     "override with go-style names maps correctly",
+			envOS:    "darwin",
+			envArch:  "amd64",
+			wantOS:   "macos",
+			wantArch: "x86_64",
+		},
+		{
+			name:     "override arch arm64 maps to aarch64",
+			envOS:    "",
+			envArch:  "arm64",
+			wantOS:   defaultOS,
+			wantArch: "aarch64",
+		},
+		{
+			name:     "override with windows",
+			envOS:    "windows",
+			envArch:  "amd64",
+			wantOS:   "windows",
+			wantArch: "x86_64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ZVM_TARGET_OS", tt.envOS)
+			t.Setenv("ZVM_TARGET_ARCH", tt.envArch)
+
+			arch, osName := zigStyleSysInfo()
+
+			if arch != tt.wantArch {
+				t.Errorf("arch = %q, want %q", arch, tt.wantArch)
+			}
+			if osName != tt.wantOS {
+				t.Errorf("os = %q, want %q", osName, tt.wantOS)
+			}
+		})
+	}
+}

--- a/cli/meta/version.go
+++ b/cli/meta/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	VERSION = "v0.8.18"
+	VERSION = "v0.8.19"
 
 	// VERSION = "v0.0.0" // For testing zvm upgrade
 

--- a/cli/resolve.go
+++ b/cli/resolve.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Tristan Isham. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"golang.org/x/mod/semver"
+)
+
+// resolveVersionShorthand takes a possibly-abbreviated version string and a
+// list of available version strings, and returns the best matching full version.
+// Examples:
+//
+//	"0.12"  + ["0.12.0", "0.13.0"]  -> "0.12.0"
+//	".12"   + ["0.12.0", "0.13.0"]  -> "0.12.0"
+//	"0.15"  + ["0.15.0", "0.15.1"]  -> "0.15.1" (latest patch)
+//	"0.12.0" + ["0.12.0"]           -> "0.12.0" (exact, unchanged)
+func resolveVersionShorthand(input string, available []string) (string, error) {
+	log.Debug("resolveVersionShorthand", "input", input, "candidates", len(available))
+
+	if input == "" {
+		return "", fmt.Errorf("empty version string")
+	}
+
+	// Normalize: ".12" -> "0.12"
+	if strings.HasPrefix(input, ".") {
+		normalized := "0" + input
+		log.Debug("normalized dot prefix", "from", input, "to", normalized)
+		input = normalized
+	}
+
+	// Special non-semver names pass through unchanged
+	if isSpecialVersion(input) {
+		log.Debug("special version passthrough", "version", input)
+		return input, nil
+	}
+
+	// "stable" resolves to the highest non-dev, non-master release
+	if input == "stable" {
+		log.Debug("resolving stable alias")
+		return resolveStable(available)
+	}
+
+	// Exact match — return immediately
+	if slices.Contains(available, input) {
+		log.Debug("exact version match", "version", input)
+		return input, nil
+	}
+
+	// Prefix match: "0.12" matches "0.12.0", "0.12.1", etc.
+	// Using input+"." prevents "0.1" from matching "0.13.0"
+	var matches []string
+	prefix := input + "."
+	for _, v := range available {
+		if isSpecialVersion(v) {
+			continue
+		}
+		if strings.HasPrefix(v, prefix) {
+			matches = append(matches, v)
+		}
+	}
+
+	if len(matches) == 0 {
+		log.Debug("no prefix matches found", "input", input)
+		return input, nil
+	}
+
+	resolved := latestVersion(matches)
+	log.Debug("prefix match resolved", "input", input, "matches", matches, "resolved", resolved)
+	return resolved, nil
+}
+
+// isSpecialVersion returns true for non-semver version identifiers
+// that should not be resolved via prefix matching.
+func isSpecialVersion(v string) bool {
+	switch v {
+	case "master", "latest":
+		return true
+	}
+	return false
+}
+
+// resolveStable returns the highest non-dev, non-master release version.
+func resolveStable(available []string) (string, error) {
+	var releases []string
+	for _, v := range available {
+		if isSpecialVersion(v) {
+			continue
+		}
+		if strings.Contains(v, "-dev") {
+			log.Debug("resolveStable: skipping dev version", "version", v)
+			continue
+		}
+		// Must be valid semver
+		if !semver.IsValid("v" + v) {
+			log.Debug("resolveStable: skipping invalid semver", "version", v)
+			continue
+		}
+		releases = append(releases, v)
+	}
+	if len(releases) == 0 {
+		log.Debug("resolveStable: no stable releases found")
+		return "", fmt.Errorf("no stable release found")
+	}
+	stable := latestVersion(releases)
+	log.Debug("resolveStable", "stable", stable, "releaseCount", len(releases))
+	return stable, nil
+}
+
+// latestVersion returns the highest semver version from a non-empty slice.
+// Version strings are expected without a "v" prefix (e.g. "0.12.0").
+func latestVersion(versions []string) string {
+	best := versions[0]
+	for _, v := range versions[1:] {
+		if semver.Compare("v"+v, "v"+best) > 0 {
+			best = v
+		}
+	}
+	return best
+}

--- a/cli/resolve_test.go
+++ b/cli/resolve_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Tristan Isham. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package cli
+
+import "testing"
+
+// allZigVersions mirrors the real Zig release index as of 2026-04.
+var allZigVersions = []string{
+	"0.1.1", "0.2.0", "0.3.0", "0.4.0", "0.5.0",
+	"0.6.0", "0.7.0", "0.7.1", "0.8.0", "0.8.1",
+	"0.9.0", "0.9.1", "0.10.0", "0.10.1",
+	"0.11.0", "0.12.0", "0.12.1", "0.13.0",
+	"0.14.0", "0.14.1",
+	"0.15.0", "0.15.1", "0.15.2",
+	"0.16.0",
+	"master",
+}
+
+func TestResolveVersionShorthand(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		// Exact matches
+		{name: "exact 0.12.0", input: "0.12.0", want: "0.12.0"},
+		{name: "exact 0.14.1", input: "0.14.1", want: "0.14.1"},
+		{name: "exact 0.16.0", input: "0.16.0", want: "0.16.0"},
+		{name: "exact 0.1.1", input: "0.1.1", want: "0.1.1"},
+
+		// Minor shorthand — single patch
+		{name: "shorthand 0.13", input: "0.13", want: "0.13.0"},
+		{name: "shorthand 0.16", input: "0.16", want: "0.16.0"},
+		{name: "shorthand 0.11", input: "0.11", want: "0.11.0"},
+		{name: "shorthand 0.6", input: "0.6", want: "0.6.0"},
+
+		// Minor shorthand — picks latest patch
+		{name: "shorthand 0.15 latest", input: "0.15", want: "0.15.2"},
+		{name: "shorthand 0.12 latest", input: "0.12", want: "0.12.1"},
+		{name: "shorthand 0.14 latest", input: "0.14", want: "0.14.1"},
+		{name: "shorthand 0.7 latest", input: "0.7", want: "0.7.1"},
+		{name: "shorthand 0.8 latest", input: "0.8", want: "0.8.1"},
+		{name: "shorthand 0.9 latest", input: "0.9", want: "0.9.1"},
+		{name: "shorthand 0.10 latest", input: "0.10", want: "0.10.1"},
+
+		// Dot prefix shorthand
+		{name: "dot .12", input: ".12", want: "0.12.1"},
+		{name: "dot .15", input: ".15", want: "0.15.2"},
+		{name: "dot .13", input: ".13", want: "0.13.0"},
+		{name: "dot .16", input: ".16", want: "0.16.0"},
+		{name: "dot .7", input: ".7", want: "0.7.1"},
+		{name: "dot .1", input: ".1", want: "0.1.1"},
+
+		// Special versions
+		{name: "master passthrough", input: "master", want: "master"},
+
+		// Stable alias
+		{name: "stable resolves to latest release", input: "stable", want: "0.16.0"},
+
+		// No match — returns input unchanged
+		{name: "no match 0.99", input: "0.99", want: "0.99"},
+		{name: "no match 1.0", input: "1.0", want: "1.0"},
+
+		// Empty input
+		{name: "empty string errors", input: "", wantErr: true},
+
+		// Prevents false prefix matches
+		{name: "0.1 does not match 0.10.x or 0.11.x etc", input: "0.1", want: "0.1.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveVersionShorthand(tt.input, allZigVersions)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveVersionShorthand(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveStable(t *testing.T) {
+	tests := []struct {
+		name      string
+		available []string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "all real versions",
+			available: allZigVersions,
+			want:      "0.16.0",
+		},
+		{
+			name:      "with dev version",
+			available: []string{"0.13.0", "0.14.0-dev.123+abc", "master"},
+			want:      "0.13.0",
+		},
+		{
+			name:      "only master",
+			available: []string{"master"},
+			wantErr:   true,
+		},
+		{
+			name:      "only dev versions",
+			available: []string{"master", "0.17.0-dev.76+ff612334f"},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveStable(tt.available)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveStable() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLatestVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions []string
+		want     string
+	}{
+		{name: "single", versions: []string{"0.12.0"}, want: "0.12.0"},
+		{name: "multiple", versions: []string{"0.15.0", "0.15.2", "0.15.1"}, want: "0.15.2"},
+		{name: "two versions", versions: []string{"0.14.0", "0.14.1"}, want: "0.14.1"},
+		{name: "all releases", versions: []string{"0.1.1", "0.16.0", "0.8.0", "0.13.0"}, want: "0.16.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := latestVersion(tt.versions)
+			if got != tt.want {
+				t.Errorf("latestVersion(%v) = %q, want %q", tt.versions, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -28,12 +28,28 @@ func (z *ZVM) Run(version string, cmd []string) error {
 		return err
 	}
 
+	// Resolve shorthand against local installs
+	if resolved, resolveErr := resolveVersionShorthand(version, installedVersions); resolveErr == nil && resolved != version {
+		log.Debug("resolved version shorthand", "input", version, "resolved", resolved)
+		version = resolved
+	}
+
 	if slices.Contains(installedVersions, version) {
 		return z.runZig(version, cmd)
 	} else {
 		rawVersionStructure, err := z.fetchVersionMap()
 		if err != nil {
 			return err
+		}
+
+		// Also resolve against remote versions if not found locally
+		remoteVersions := make([]string, 0, len(rawVersionStructure))
+		for k := range rawVersionStructure {
+			remoteVersions = append(remoteVersions, k)
+		}
+		if resolved, resolveErr := resolveVersionShorthand(version, remoteVersions); resolveErr == nil && resolved != version {
+			log.Debug("resolved version shorthand (remote)", "input", version, "resolved", resolved)
+			version = resolved
 		}
 
 		_, err = getTarPath(version, &rawVersionStructure)
@@ -48,7 +64,7 @@ func (z *ZVM) Run(version string, cmd []string) error {
 		fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", version)
 
 		if getConfirmation() {
-			if err = z.Install(version, false, true); err != nil {
+			if version, err = z.Install(version, false, true); err != nil {
 				return err
 			}
 			return z.runZig(version, cmd)

--- a/cli/sync.go
+++ b/cli/sync.go
@@ -49,7 +49,7 @@ func (z *ZVM) Sync() error {
 		switch strings.ToLower(strings.TrimSpace(variablePieces[0])) {
 		case "zvm-lock":
 			val := strings.TrimSpace(variablePieces[1])
-			if err := z.Use(val); err != nil {
+			if _, err := z.Use(val); err != nil {
 				return err
 			}
 		}

--- a/cli/uninstall.go
+++ b/cli/uninstall.go
@@ -7,10 +7,21 @@ package cli
 import (
 	"fmt"
 	"os"
+
+	"github.com/charmbracelet/log"
 )
 
 // Uninstall removes the specified Zig version from the ZVM base directory.
 func (z *ZVM) Uninstall(version string) error {
+	// Resolve shorthand against locally installed versions
+	if installedVersions, err := z.GetInstalledVersions(); err == nil {
+		if resolved, resolveErr := resolveVersionShorthand(version, installedVersions); resolveErr == nil && resolved != version {
+			log.Debug("resolved version shorthand", "input", version, "resolved", resolved)
+			fmt.Printf("Resolved %q to %s\n", version, resolved)
+			version = resolved
+		}
+	}
+
 	root, err := os.OpenRoot(z.baseDir)
 	if err != nil {
 		return err
@@ -20,7 +31,7 @@ func (z *ZVM) Uninstall(version string) error {
 		if err := root.RemoveAll(version); err != nil {
 			return err
 		}
-		fmt.Printf("✔ Uninstalled %s.\nRun `zvm ls` to view installed versions.\n", version)
+		fmt.Printf("✔ Uninstalled %s\nRun `zvm ls` to view installed versions.\n", version)
 		return nil
 	}
 	fmt.Printf("Version: %s not found locally.\nHere are your installed versions:\n", version)

--- a/cli/use.go
+++ b/cli/use.go
@@ -20,22 +20,32 @@ import (
 
 // Use switches the active Zig version to the specified one.
 // If the version is not installed, it prompts the user to install it.
-func (z *ZVM) Use(ver string) error {
+// Returns the resolved version string (which may differ from input if shorthand was used).
+func (z *ZVM) Use(ver string) (string, error) {
+	// Resolve shorthand against locally installed versions
+	if installedVersions, err := z.GetInstalledVersions(); err == nil {
+		if resolved, resolveErr := resolveVersionShorthand(ver, installedVersions); resolveErr == nil && resolved != ver {
+			log.Debug("resolved version shorthand", "input", ver, "resolved", resolved)
+			fmt.Printf("Resolved %q to %s\n", ver, resolved)
+			ver = resolved
+		}
+	}
+
 	if err := z.getVersion(ver); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 
 			fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", ver)
 			if getConfirmation() {
-				if err = z.Install(ver, false, true); err != nil {
-					return err
+				if ver, err = z.Install(ver, false, true); err != nil {
+					return ver, err
 				}
 			} else {
-				return fmt.Errorf("version %s is not installed", ver)
+				return ver, fmt.Errorf("version %s is not installed", ver)
 			}
 		}
 	}
 
-	return z.setBin(ver)
+	return ver, z.setBin(ver)
 }
 
 // setBin updates the symbolic link 'bin' in the ZVM base directory to point to the specified version's bin directory.

--- a/main.go
+++ b/main.go
@@ -125,14 +125,14 @@ var zvmApp = &opts.Command{
 				}
 
 				// Install Zig
-				err := zvm.Install(req.Package, force, !cmd.Bool("nomirror"))
+				resolvedVersion, err := zvm.Install(req.Package, force, !cmd.Bool("nomirror"))
 				if err != nil {
 					return err
 				}
 
 				// Install ZLS (if requested)
 				if cmd.Bool("zls") {
-					if err := zvm.InstallZls(req.Package, zlsCompat, force); err != nil {
+					if err := zvm.InstallZls(resolvedVersion, zlsCompat, force); err != nil {
 						return err
 					}
 				}
@@ -171,11 +171,12 @@ var zvmApp = &opts.Command{
 
 					}
 
-					if err := zvm.Use(versionArg); err != nil {
+					resolvedVer, err := zvm.Use(versionArg)
+					if err != nil {
 						return err
 					}
 
-					fmt.Printf("Now using Zig %s\n", versionArg)
+					fmt.Printf("Now using Zig %s\n", resolvedVer)
 					return nil
 				}
 			},

--- a/main.go
+++ b/main.go
@@ -82,6 +82,16 @@ var zvmApp = &opts.Command{
 					Name:  "nomirror",
 					Usage: "download Zig from ziglang.org instead of a community mirror",
 				},
+				&opts.StringFlag{
+					Name:    "target-os",
+					Usage:   "override the target operating system (e.g., linux, macos, windows, freebsd)",
+					Sources: opts.EnvVars("ZVM_TARGET_OS"),
+				},
+				&opts.StringFlag{
+					Name:    "target-arch",
+					Usage:   "override the target architecture (e.g., x86_64, aarch64, arm, riscv64)",
+					Sources: opts.EnvVars("ZVM_TARGET_ARCH"),
+				},
 			},
 			Description: "To install the latest version, use `master`",
 			// Args:        true,
@@ -105,6 +115,13 @@ var zvmApp = &opts.Command{
 				zlsCompat := "only-runtime"
 				if cmd.Bool("full") {
 					zlsCompat = "full"
+				}
+
+				if v := cmd.String("target-os"); v != "" {
+					os.Setenv("ZVM_TARGET_OS", v)
+				}
+				if v := cmd.String("target-arch"); v != "" {
+					os.Setenv("ZVM_TARGET_ARCH", v)
 				}
 
 				// Install Zig


### PR DESCRIPTION
## Summary

- **Version shorthand**: `zvm i 0.13` resolves to `0.13.0`, `zvm i .15` resolves to `0.15.2` (latest patch). Works across `install`, `use`, `run`, and `rm` commands.
- **`stable` alias**: `zvm i stable` installs the latest non-dev, non-master release (e.g. `0.16.0`).
- **`--zls` fix**: Resolved version now correctly propagates to ZLS installation, fixing an issue where shorthand input was passed raw to the ZLS release worker.
- **Custom target flags**: Added `--target-os` and `--target-arch` flags to override download platform.

## Test plan

- [x] Unit tests for `resolveVersionShorthand`, `resolveStable`, `latestVersion` (27 cases covering all real Zig versions)
- [x] `go run . i 0.13` → installs 0.13.0
- [x] `go run . i .14` → installs 0.14.1 (latest patch)
- [x] `go run . i stable` → installs 0.16.0
- [x] `go run . i --zls .13` → installs Zig 0.13.0 + ZLS 0.13.0 (resolved version propagates)
- [x] `go run . i --force 0.16` → force reinstalls 0.16.0
- [x] `go run . use 0.13` / `use .14` / `use stable` → switches correctly
- [x] `go run . rm 0.13` / `rm .14` → uninstalls correct version
- [x] `go run . use master` → passes through unchanged
- [x] `go vet ./...` clean, `go test ./...` all pass
