### PR TITLE
fix false path escape error

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -786,7 +786,7 @@ func untarXZ(in, out string) error {
 			return fmt.Errorf("failed to read tar header %w", err)
 		}
 
-		target := filepath.Join(out, filepath.Clean(header.Name))
+		target := filepath.Clean(header.Name)
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/cli/install.go
+++ b/cli/install.go
@@ -790,7 +790,7 @@ func untarXZ(in, out string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := root.MkdirAll(target, header.FileInfo().Mode()); err != nil {
+			if err := root.MkdirAll(target, header.FileInfo().Mode()&(^fs.ModeDir)); err != nil {
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 


### PR DESCRIPTION
Fixes:
```
2026/05/24 09:05:30 FATA failed to create directory: mkdirat /opt/zig/zig-x86_64-linux-0.17.0-dev.332+4a65cc4ac: path escapes from parent
```
and
```
2026/05/24 08:42:50 FATA failed to create directory: mkdirat /opt/zig/zig-x86_64-linux-0.17.0-dev.332+4a65cc4ac: unsupported file mode
```