### PR TITLE
added support for http.timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ zvm i --force master
 You can also enable the old behavior by setting the new `alwaysForceInstall`
 field to `true` in `~/.zvm/settings.json`.
 
+### Customize HTTP Timeout
+You can pass a custom HTTP timeout (in seconds) for `zvm i` using the `--http.timeout` flag or by setting the `ZVM_HTTP_TIMEOUT` environment variable.
+
+```sh
+zvm i --http.timeout 30
+```
+
 ### Install ZLS with ZVM
 
 You can now install ZLS with your Zig download! To install ZLS with ZVM, simply

--- a/cli/install.go
+++ b/cli/install.go
@@ -38,7 +38,7 @@ import (
 	"github.com/tristanisham/clr"
 )
 
-const HTTP_DEFAULT_TIMEOUT = 30 * time.Second
+const httpDefaultTimeout = 30 * time.Second
 
 // Install downloads and installs the specified Zig version.
 // It handles checking for existing installations, verifying checksums,

--- a/cli/install.go
+++ b/cli/install.go
@@ -348,10 +348,10 @@ func attemptDownload(url string, client *http.Client) (*http.Response, error) {
 		if err == nil {
 			client.Timeout = time.Duration(timeout) * time.Second
 		} else {
-			client.Timeout = HTTP_DEFAULT_TIMEOUT
+			client.Timeout = httpDefaultTimeout
 		}
 	} else {
-		client.Timeout = HTTP_DEFAULT_TIMEOUT
+		client.Timeout = httpDefaultTimeout
 	}
 
 	log.Debug("using client", "timeout", client.Timeout.String())

--- a/cli/install.go
+++ b/cli/install.go
@@ -339,7 +339,7 @@ func attemptDownload(url string, client *http.Client) (*http.Response, error) {
 	}
 
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{}
 	}
 
 	envTimeout := os.Getenv("ZVM_HTTP_TIMEOUT")

--- a/cli/install.go
+++ b/cli/install.go
@@ -340,16 +340,18 @@ func attemptDownload(url string, client *http.Client) (*http.Response, error) {
 
 	if client == nil {
 		client = http.DefaultClient
+	}
 
-		envTimeout := os.Getenv("ZVM_HTTP_TIMEOUT")
-		if envTimeout != "" {
-			timeout, err := strconv.Atoi(envTimeout)
-			if err == nil {
-				client.Timeout = time.Duration(timeout) * time.Second
-			}
+	envTimeout := os.Getenv("ZVM_HTTP_TIMEOUT")
+	if envTimeout != "" {
+		timeout, err := strconv.Atoi(envTimeout)
+		if err == nil {
+			client.Timeout = time.Duration(timeout) * time.Second
 		} else {
 			client.Timeout = HTTP_DEFAULT_TIMEOUT
 		}
+	} else {
+		client.Timeout = HTTP_DEFAULT_TIMEOUT
 	}
 
 	log.Debug("using client", "timeout", client.Timeout.String())
@@ -363,10 +365,8 @@ func attemptDownload(url string, client *http.Client) (*http.Response, error) {
 		}
 
 		log.Debug("ZVM_SKIP_TLS_VERIFY", "enabled", true)
-		client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	} else {
 		// Yeah, yeah. Just an easy way to do the call.

--- a/cli/install.go
+++ b/cli/install.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,14 +38,16 @@ import (
 	"github.com/tristanisham/clr"
 )
 
+const HTTP_DEFAULT_TIMEOUT = 30 * time.Second
+
 // Install downloads and installs the specified Zig version.
 // It handles checking for existing installations, verifying checksums,
 // and extracting the downloaded bundle.
 func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
-	err := os.MkdirAll(z.baseDir, 0755)
-	if err != nil {
+	if err := os.MkdirAll(z.baseDir, 0755); err != nil {
 		return version, err
 	}
+
 	rawVersionStructure, err := z.fetchVersionMap()
 	if err != nil {
 		return version, err
@@ -112,7 +115,7 @@ func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
 	if mirror {
 		tarResp, minisig, err = attemptMirrorDownload(z.Settings.MirrorListUrl, tarPath)
 	} else {
-		tarResp, err = attemptDownload(tarPath)
+		tarResp, err = attemptDownload(tarPath, nil)
 	}
 
 	if err != nil {
@@ -267,7 +270,7 @@ func attemptMirrorDownload(mirrorListURL string, tarURL string) (*http.Response,
 	}
 	tarName := path.Base(tarURLParsed.Path)
 
-	resp, err := attemptDownload(mirrorListURL)
+	resp, err := attemptDownload(mirrorListURL, nil)
 	if err != nil {
 		return nil, minisign.Signature{}, fmt.Errorf("%w: %w", ErrDownloadFail, err)
 	}
@@ -293,13 +296,13 @@ func attemptMirrorDownload(mirrorListURL string, tarURL string) (*http.Response,
 		}
 
 		log.Debug("attemptMirrorDownload", "mirror", i, "mirrorURL", mirrorTarURL)
-		tarResp, err := attemptDownload(mirrorTarURL)
+		tarResp, err := attemptDownload(mirrorTarURL, nil)
 		if err != nil {
 			log.Debug("mirror tar error", "mirror", mirror, "error", err)
 			continue
 		}
 
-		minisig, err := attemptMinisigDownload(mirrorTarURL)
+		minisig, err := attemptMinisigDownload(mirrorTarURL, nil)
 		if err != nil {
 			log.Debug("mirror minisig error", "mirror", mirror, "error", err)
 			tarResp.Body.Close()
@@ -313,8 +316,8 @@ func attemptMirrorDownload(mirrorListURL string, tarURL string) (*http.Response,
 }
 
 // attemptMinisigDownload downloads the minisign signature for a given tarball URL.
-func attemptMinisigDownload(tarURL string) (minisign.Signature, error) {
-	minisigResp, err := attemptDownload(tarURL + ".minisig")
+func attemptMinisigDownload(tarURL string, client *http.Client) (minisign.Signature, error) {
+	minisigResp, err := attemptDownload(tarURL+".minisig", client)
 	if err != nil {
 		return minisign.Signature{}, err
 	}
@@ -329,13 +332,27 @@ func attemptMinisigDownload(tarURL string) (minisign.Signature, error) {
 }
 
 // attemptDownload creates a generic http request for ZVM.
-func attemptDownload(url string) (*http.Response, error) {
+func attemptDownload(url string, client *http.Client) (*http.Response, error) {
 	req, err := createDownloadReq(url)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrDownloadFail, err)
 	}
 
-	client := http.DefaultClient
+	if client == nil {
+		client = http.DefaultClient
+
+		envTimeout := os.Getenv("ZVM_HTTP_TIMEOUT")
+		if envTimeout != "" {
+			timeout, err := strconv.Atoi(envTimeout)
+			if err == nil {
+				client.Timeout = time.Duration(timeout) * time.Second
+			}
+		} else {
+			client.Timeout = HTTP_DEFAULT_TIMEOUT
+		}
+	}
+
+	log.Debug("using client", "timeout", client.Timeout.String())
 
 	// Checks the ZVM_SKIP_TLS_VERIFY environment variable and
 	// toggles verifying a secure connection.
@@ -499,7 +516,7 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 
 	log.Debug("tarPath", "url", tarPath)
 
-	tarResp, err := attemptDownload(tarPath)
+	tarResp, err := attemptDownload(tarPath, nil)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ var zvmApp = &opts.Command{
 					os.Setenv("ZVM_TARGET_ARCH", v)
 				}
 
+				// HTTP Settings
 				if v := cmd.Int("http.timeout"); v != 0 {
 					os.Setenv("ZVM_HTTP_TIMEOUT", strconv.Itoa(v))
 				}

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ var zvmApp = &opts.Command{
 				}
 
 				// HTTP Settings
-				if v := cmd.Int("http.timeout"); v != 0 {
+				if v := cmd.Int64("http.timeout"); v != 0 {
 					os.Setenv("ZVM_HTTP_TIMEOUT", strconv.FormatInt(v, 10))
 				}
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -101,6 +102,11 @@ var zvmApp = &opts.Command{
 					Usage:   "override the target architecture (e.g., x86_64, aarch64, arm, riscv64)",
 					Sources: opts.EnvVars("ZVM_TARGET_ARCH"),
 				},
+				&opts.IntFlag{
+					Name:    "http.timeout",
+					Usage:   "set a custom timeout for http requests",
+					Sources: opts.EnvVars("ZVM_HTTP_TIMEOUT"),
+				},
 			},
 			Description: "To install the latest version, use `master`",
 			// Args:        true,
@@ -129,8 +135,13 @@ var zvmApp = &opts.Command{
 				if v := cmd.String("target-os"); v != "" {
 					os.Setenv("ZVM_TARGET_OS", v)
 				}
+
 				if v := cmd.String("target-arch"); v != "" {
 					os.Setenv("ZVM_TARGET_ARCH", v)
+				}
+
+				if v := cmd.Int("http.timeout"); v != 0 {
+					os.Setenv("ZVM_HTTP_TIMEOUT", strconv.Itoa(v))
 				}
 
 				// Install Zig

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ var zvmApp = &opts.Command{
 				}
 
 				if v := cmd.Int("http.timeout"); v != 0 {
-					os.Setenv("ZVM_HTTP_TIMEOUT", strconv.Itoa(v))
+					os.Setenv("ZVM_HTTP_TIMEOUT", strconv.FormatInt(v, 10))
 				}
 
 				// Install Zig


### PR DESCRIPTION
This pull request closes #168 and enables the user to customize the timeout for http requests when running install. That way if a mirror goes down, or is taking forever, you have the choice to cut it off. 