### PR TITLE
Feat/install http timeout

### DIFF
--- a/cli/install.go
+++ b/cli/install.go
@@ -38,7 +38,7 @@ import (
 	"github.com/tristanisham/clr"
 )
 
-const httpDefaultTimeout = 30 * time.Second
+const httpDefaultTimeout = (60 * 3) * time.Second
 
 // Install downloads and installs the specified Zig version.
 // It handles checking for existing installations, verifying checksums,

--- a/cli/meta/version.go
+++ b/cli/meta/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "v0.8.23"
+	VERSION = "v0.8.24"
 
 	// VERSION = "v0.0.0" // For testing zvm upgrade
 

--- a/cli/meta/version.go
+++ b/cli/meta/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "v0.8.24"
+	VERSION = "v0.8.25"
 
 	// VERSION = "v0.0.0" // For testing zvm upgrade
 


### PR DESCRIPTION
In the last version of zvm, I introduced a timeout feature for long-running http requests. Turns out, 10 seconds was not enough and *it works on my machine* struck again.

I set the new default to 3 minutes per request. As always, you can customize the timeout per invocation `--http.timeout=<int>` or by setting the `ZVM_DEFAULT_TIMEOUT` environment variable to an integer. 

