### PR TITLE
docs: added PATH instructions for Linux/MacOS/Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ up manually, append the following to your shell's startup file (`~/.bashrc`,
 
 ```sh
 export ZVM_INSTALL="$HOME/.zvm/self"
-export PATH="$PATH:$HOME/.zvm/bin"
-export PATH="$PATH:$ZVM_INSTALL/"
+export PATH="$HOME/.zvm/bin:$ZVM_INSTALL:$PATH"
 ```
 
 Then restart your shell or `source` the file for the changes to take effect.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,26 @@ instead for building the app.
 
 ## Putting ZVM on your Path
 
-ZVM requires a few directories to be on your `$PATH`. If you don't know how to
-update your environment variables permanently on Windows, you can follow
+ZVM requires a few directories to be on your `$PATH`.
+
+### Linux, BSD, MacOS, *nix
+
+The installer script handles this for you automatically. If you need to set it
+up manually, append the following to your shell's startup file (`~/.bashrc`,
+`~/.zshrc`, or `~/.profile`):
+
+```sh
+export ZVM_INSTALL="$HOME/.zvm/self"
+export PATH="$PATH:$HOME/.zvm/bin"
+export PATH="$PATH:$ZVM_INSTALL/"
+```
+
+Then restart your shell or `source` the file for the changes to take effect.
+
+### Windows
+
+If you don't know how to update your environment variables permanently on
+Windows, you can follow
 [this guide](https://www.computerhope.com/issues/ch000549.htm). Once you're in
 the appropriate menu, add or append to the following environment variables:
 


### PR DESCRIPTION
The "Putting ZVM on your Path" section only had `Windows` instructions, so I added a Linux/macOS subsection with the export lines to copy-paste. The *nix setup is mentioned at the top of the docs but it's easy to miss if you jump to the installation part.