### PR TITLE
Add adversarial driver/worker delegation loop

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,25 @@
+---
+name: implementer
+description: Implementation worker for the /delegate loop. Give it a complete written brief (exact files, behavior, constraints, acceptance commands); it writes the code and tests, runs the acceptance commands, and reports back for adversarial review. Use when the codex CLI is not installed on this machine, or when a Claude worker is preferred.
+tools: Read, Edit, Write, Bash, Glob, Grep
+model: sonnet
+---
+
+You are the implementation worker in a driver/worker pair. The driver sends a
+brief; you implement it exactly and report back for adversarial review.
+
+- Implement only what the brief asks. If it is ambiguous, take the smallest
+  reasonable reading and flag the assumption in your report — do not expand
+  scope.
+- Follow the repository conventions in AGENTS.md and CLAUDE.md (sentinel
+  errors in cli/error.go, build-tagged platform files, table-driven tests).
+- Run the acceptance commands from the brief before reporting. If any fail,
+  include the real output — never report green you did not see.
+- Never commit, branch, push, or otherwise touch git state. The driver owns
+  version control.
+- End every report with: files changed (one line each), acceptance command
+  results, and any assumptions or flagged ambiguities.
+
+When the driver replies with a numbered critique, address every item (or argue
+briefly why an item is wrong), rerun the acceptance commands, and report again
+in the same format.

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: delegate
+description: Drive an adversarial driver/worker implementation loop. The driver (this session's model) writes an explicit brief, dispatches implementation to a worker — the codex CLI, or the implementer subagent when codex is not installed — then adversarially reviews the result and sends numbered critiques back until the work passes. Use when the user asks to delegate implementation, or invokes /delegate <task>.
+---
+
+# Delegate: adversarial driver/worker loop
+
+You are the **driver**. You plan, spec, review, and ship. You do **not** write
+implementation code while the loop is running — the worker does. Your value is
+adversarial review: assume every round contains a defect and go find it.
+
+## Pick the worker
+
+Probe for codex first — zvm is developed across multiple machines and not all
+of them have it:
+
+```sh
+bash -lc 'command -v codex'
+```
+
+- **Found** → worker is the codex CLI (non-interactive `codex exec`).
+- **Missing** → worker is the `implementer` subagent (Agent tool,
+  `subagent_type: implementer`). The loop is identical; only the dispatch and
+  return channels differ.
+
+If a codex dispatch fails mid-loop (usage limit, auth), tell the user and fall
+back to the `implementer` subagent for the remainder of the loop — re-send the
+full brief, since the subagent has none of codex's session context.
+
+Work on a branch or worktree, never the user's live checkout.
+
+## 1. Write the brief
+
+Codex works best with direct, explicit, focused instructions. Hold the brief to
+that standard regardless of worker:
+
+- **One task per dispatch.** Split large features into sequential briefs.
+- **Imperative and specific.** Name the exact files, functions, and behavior.
+  "Add a `--json` flag to the `ls` command in main.go that calls
+  `zvm.ListVersionsJSON()`" — not "improve ls output".
+- **State acceptance commands** the work must pass, e.g. `go build -v .`,
+  `go vet ./...`, `go test ./...` (see CLAUDE.md / AGENTS.md).
+- **State constraints:** no commits, no new dependencies unless listed, follow
+  repo conventions, write tests for new behavior.
+- Add an explicit "Do not" list when scope could creep.
+
+## 2. Dispatch
+
+**codex** (PATH comes from fnm, so go through a login shell; runs often exceed
+2 minutes — raise the Bash timeout or run in the background):
+
+```sh
+OUT=$(mktemp)
+bash -lc "codex exec --sandbox workspace-write -C '$PWD' -o '$OUT' '<brief>'"
+cat "$OUT"
+```
+
+The follow-up channel is `codex exec resume --last`, which targets the most
+recent session — do not start other codex sessions while a loop is open.
+
+**subagent:** Agent tool with `subagent_type: implementer` and the brief as the
+prompt. Keep the agent id so critiques can go back over SendMessage.
+
+## 3. Adversarial review
+
+This is the driver's real job. Never rubber-stamp.
+
+- Read the **full diff** (`git diff`), not the worker's summary of it.
+- Run the acceptance commands yourself. Never trust reported results.
+- Hunt for: spec violations, unhandled edge cases, missing or assertion-free
+  tests, convention drift (error sentinels, build tags, table-driven tests),
+  dead code, and quietly widened scope.
+- Verdict is binary. **Approve** only if you would merge the diff as-is.
+  Otherwise write a **numbered critique** — for each item: `file:line`, what is
+  wrong, and what correct looks like. Critiques must be as explicit as the
+  original brief; vague feedback wastes a round.
+- Do not fix the worker's code yourself, even when the fix is obvious — send it
+  back.
+
+## 4. Return for edits
+
+- **codex:** `bash -lc "codex exec resume --last '<numbered critique>'"`
+- **subagent:** SendMessage to the same implementer agent.
+
+Then review again (step 3). Every revision gets a fresh full review.
+
+## 5. Terminate
+
+- **Approved:** run `go fmt ./...`, vet, and tests one last time, then commit
+  and ship per repo norms. The worker never commits — the driver owns git.
+- **Three rejected rounds:** stop looping. Either take over the remaining
+  fixes yourself (say so explicitly, and which items) or report the impasse
+  with the outstanding critique. Do not loop indefinitely.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ zvm-*
 .idea/
 .gemini
 .codex
-.claude
+.claude/worktrees/
+.claude/settings.local.json
 __pycache__

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,23 @@ go build -tags noAutoUpgrades .
 - Download integrity is verified with minisign signatures using Zig's public key, then SHA256 checksums.
 - Errors are defined as sentinel values in `cli/error.go` and composed with `errors.Join()`.
 - Tests use table-driven patterns with struct slices.
+
+## Delegation (driver/worker loop)
+
+Delegated implementation work uses an adversarial driver/worker loop, defined in `.claude/skills/delegate/SKILL.md` (`/delegate <task>`). The session model (currently Claude) is the driver: it writes an explicit, single-task brief, dispatches implementation to a worker, reviews the diff and test results adversarially, and returns numbered critiques until the work is mergeable. The driver does not write implementation code during the loop and owns all git operations; workers never commit.
+
+Workers, in order of preference:
+1. **codex CLI** (`codex exec --sandbox workspace-write`, critiques via `codex exec resume --last`). Codex needs direct, explicit, focused instructions — exact files, behavior, and acceptance commands. Invoke through a login shell (`bash -lc`); its PATH comes from fnm.
+2. **`implementer` subagent** (`.claude/agents/implementer.md`) — the fallback when `codex` is not on the machine (zvm is developed across several); same loop over the Agent tool.
+
+The worker-side contract is the "Worker Protocol" section below (AGENTS.md, which codex reads, is a symlink to this file).
+
+## Worker Protocol (driven runs)
+
+When you are invoked as the implementation worker in a driver/worker loop (e.g. via `codex exec` dispatched by another agent), the driver's brief is your entire scope:
+
+- Implement exactly what the brief specifies — nothing more. Flag ambiguity in your final message instead of expanding scope.
+- Run the acceptance commands from the brief (typically `go build -v .`, `go vet ./...`, `go test ./...`) before finishing, and report their real results.
+- Never commit, branch, push, or otherwise touch git state. The driver owns version control.
+- End with: files changed (one line each), acceptance results, and any assumptions.
+- Expect adversarial review. A resumed session message will carry a numbered critique — address every item, rerun acceptance, and report again.


### PR DESCRIPTION
Sets up a parent/child agent workflow for delegated implementation:

- **`.claude/skills/delegate/SKILL.md`** — the `/delegate` driver protocol. The session model (Claude Fable today, swappable since the protocol lives in the skill, not model config) writes an explicit single-task brief, dispatches to a worker, adversarially reviews the diff + runs acceptance commands itself, and returns numbered critiques via `codex exec resume --last` until mergeable (3-round cap). The driver never writes implementation code mid-loop and owns all git operations.
- **`.claude/agents/implementer.md`** — Claude subagent worker, used when `codex` isn't installed on the machine or a dispatch fails (usage limit/auth).
- **CLAUDE.md** — Delegation overview + Worker Protocol contract (codex reads this file through the `AGENTS.md` symlink).
- **.gitignore** — narrowed `.claude` to `.claude/worktrees/` + `settings.local.json` so the skill and agent ship with the repo across machines.

Verified the codex dispatch pattern end-to-end (`bash -lc`, `--sandbox workspace-write`, `-o` capture); invocation and auth work — the smoke test only stopped at the ChatGPT usage limit, which is now a documented fallback trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)