### PR TITLE
Show aliases in zvm ls output

### DIFF
--- a/cli/ls.go
+++ b/cli/ls.go
@@ -50,20 +50,45 @@ func (z *ZVM) ListVersions() error {
 		fmt.Printf("No local Zig installs. Run `%s` to list all available-to-install versions of Zig.\n", cmdHelp)
 	}
 
-	for _, key := range installedVersions {
-		if key == strings.TrimSpace(version) || key == "master" && strings.Contains(version, "-dev.") {
-			if z.Settings.UseColor {
-				// Should just check bin for used version
-				fmt.Println(clr.Green(key))
-			} else {
-				fmt.Println(key + " [x]")
-			}
-		} else {
-			fmt.Println(key)
+	var aliasesByVersion map[string][]string
+	if z.db == nil {
+		log.Debug("alias database unavailable; listing versions without aliases")
+	} else {
+		aliasesByVersion, err = z.aliasesByVersion(context.Background())
+		if err != nil {
+			return err
 		}
 	}
 
+	for _, key := range installedVersions {
+		active := key == strings.TrimSpace(version) || key == "master" && strings.Contains(version, "-dev.")
+		fmt.Println(formatVersionLine(key, formatAliasColumn(aliasesByVersion[key]), active, z.Settings.UseColor))
+	}
+
 	return nil
+}
+
+// formatVersionLine renders a single line of `zvm ls` output for an installed
+// version, optionally marking it active and appending an alias column.
+func formatVersionLine(version, aliasCol string, active, useColor bool) string {
+	var line string
+	switch {
+	case active && useColor:
+		line = clr.Green(version)
+	case active && !useColor:
+		line = version + " [x]"
+	default:
+		line = version
+	}
+
+	if aliasCol != "" {
+		if useColor {
+			aliasCol = clr.Blue(aliasCol)
+		}
+		line += "  " + aliasCol
+	}
+
+	return line
 }
 
 // GetInstalledVersions returns a slice of strings containing the names of

--- a/cli/ls_alias_test.go
+++ b/cli/ls_alias_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/tristanisham/clr"
+)
 
 func TestFormatAliasColumn(t *testing.T) {
 	tests := []struct {
@@ -17,6 +21,66 @@ func TestFormatAliasColumn(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := formatAliasColumn(tt.aliases); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatVersionLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		aliasCol string
+		active   bool
+		useColor bool
+		want     string
+	}{
+		{
+			name:     "inactive without aliases",
+			version:  "0.13.0",
+			aliasCol: "",
+			active:   false,
+			useColor: false,
+			want:     "0.13.0",
+		},
+		{
+			name:     "inactive with aliases",
+			version:  "0.13.0",
+			aliasCol: "stable",
+			active:   false,
+			useColor: false,
+			want:     "0.13.0  stable",
+		},
+		{
+			name:     "active without color",
+			version:  "0.13.0",
+			aliasCol: "",
+			active:   true,
+			useColor: false,
+			want:     "0.13.0 [x]",
+		},
+		{
+			name:     "active with color",
+			version:  "0.13.0",
+			aliasCol: "",
+			active:   true,
+			useColor: true,
+			want:     clr.Green("0.13.0"),
+		},
+		{
+			name:     "active with color and aliases",
+			version:  "0.13.0",
+			aliasCol: "stable",
+			active:   true,
+			useColor: true,
+			want:     clr.Green("0.13.0") + "  " + clr.Blue("stable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatVersionLine(tt.version, tt.aliasCol, tt.active, tt.useColor); got != tt.want {
 				t.Fatalf("expected %q, got %q", tt.want, got)
 			}
 		})


### PR DESCRIPTION
First real run of the `/delegate` adversarial loop (PR #179). The driver (Claude) wrote the brief and reviewed; the worker implemented.

- `zvm ls` now appends each installed version's aliases (blue when color is enabled) using the previously unused `formatAliasColumn` helper
- New pure `formatVersionLine` helper with table-driven tests, so line rendering is unit-testable
- Degrades to the plain listing when the alias database failed to initialize (`Initialize()` continues with a nil `db`; without the guard, `zvm ls`/`zvm rm` would panic — caught in adversarial review round 1)

Loop stats: codex was rate-limited, so the implementer-subagent fallback carried the task. Two rounds: round 1 faithful but crash-prone on nil db, round 2 approved. Verified end-to-end in a sandbox `ZVM_PATH`:

```
$ zvm ls
0.13.0  work
master  nightly
```

Note: `TestCompletionUnknownShell` fails on clean `feat/alias` too (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)