### PR TITLE
Port ls-remote improvements and JSON output from feat/alias

### DIFF
--- a/cli/ls.go
+++ b/cli/ls.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/tristanisham/clr"
+	"github.com/tristanisham/zvm/cli/meta"
 )
 
 // ListVersions prints the installed Zig versions and marks the current version.
@@ -84,6 +86,15 @@ func (z *ZVM) GetInstalledVersions() ([]string, error) {
 	return versions, nil
 }
 
+type RemoteVersionJSON struct {
+	Version       string `json:"version"`
+	Installed     bool   `json:"installed"`
+	ZLS           bool   `json:"zls"`
+	RemoteVersion string `json:"remoteVersion,omitempty"`
+	LocalVersion  string `json:"localVersion,omitempty"`
+	Outdated      bool   `json:"outdated,omitempty"`
+}
+
 // ListRemoteAvailable lists all available Zig versions from the remote version map,
 // indicating which ones are already installed and which have ZLS support.
 func (z ZVM) ListRemoteAvailable() error {
@@ -112,7 +123,7 @@ func (z ZVM) ListRemoteAvailable() error {
 	semver.Sort(options)
 	slices.Reverse(options)
 
-	fmt.Printf("%-12s%-12s%s\n", "Version", "Installed", "ZLS")
+	fmt.Printf("%s%s%s\n", meta.TableVersionHeaderStyle.Render("Version"), meta.TableInstalledHeaderStyle.Render("Installed"), meta.TableHeaderStyle.Render("ZLS"))
 
 	for _, version := range options {
 		stripped := version[1:]
@@ -123,12 +134,20 @@ func (z ZVM) ListRemoteAvailable() error {
 
 		installed := ""
 		if slices.Contains(installedVersions, stripped) {
-			installed = "[installed]"
+			if z.Settings.UseColor {
+				installed = "installed"
+				coloredStr := meta.TableInstalledVersionStyle.Render(installed)
+				// keep the extra space. It fixes a rendering bug.
+				installed = fmt.Sprintf("[%s] ", coloredStr)
+			} else {
+				installed = "[installed]"
+
+			}
 		}
 
 		zlsInfo := ""
 		if _, ok := zlsVersions[stripped]; ok {
-			zlsInfo = "(zls tagged)"
+			zlsInfo = "(tagged)"
 		}
 
 		fmt.Printf("%-12s%-12s%s\n", stripped, installed, zlsInfo)
@@ -144,9 +163,13 @@ func (z ZVM) ListRemoteAvailable() error {
 
 		zlsInfo := ""
 		if _, ok := zlsVersions["master"]; ok {
-			zlsInfo = "(zls tagged)"
+			zlsInfo = "(tagged)"
 		}
-		fmt.Printf("%-12s%-12s%s\n", fmt.Sprintf("master (remote) (%s)", remoteVersion), "", zlsInfo)
+		remoteLabel := "remote"
+		if z.Settings.UseColor {
+			remoteLabel = meta.TableRemoteVersionStyle.Render(remoteLabel)
+		}
+		fmt.Printf("%-12s%-12s%s\n", fmt.Sprintf("master (%s) (%s)", remoteLabel, remoteVersion), "", zlsInfo)
 
 		// Check if master is installed and print local version
 		if slices.Contains(installedVersions, "master") {
@@ -162,15 +185,99 @@ func (z ZVM) ListRemoteAvailable() error {
 
 				outDated := ""
 				if localVersion != remoteVersion {
-					outDated = "[outdated]"
+					if z.Settings.UseColor {
+						outDated = fmt.Sprintf("[%s] ", meta.TableOutdatedVersionStyle.Render("outdated"))
+					} else {
+						outDated = "[outdated]"
+					}
+				}
+
+				localLabel := "local"
+				installed := "[installed]"
+				if z.Settings.UseColor {
+					localLabel = meta.TableLocalVersionStyle.Render(localLabel)
+					installed = fmt.Sprintf("[%s] ", meta.TableInstalledVersionStyle.Render("installed"))
 				}
 
 				fmt.Println("--------------------------------------------")
-				fmt.Printf("%-15s (%-15s) %-10s %-10s\n", "master (local)", localVersion, "[installed]", outDated)
+				fmt.Printf("%-15s (%-15s) %-10s %-10s\n", fmt.Sprintf("master (%s)", localLabel), localVersion, installed, outDated)
 
 			}
 		}
 	}
 
 	return nil
+}
+
+func (z ZVM) ListRemoteAvailableJSON() error {
+	zigVersions, err := z.fetchVersionMap()
+	if err != nil {
+		return err
+	}
+
+	zlsVersions, err := z.fetchZlsTaggedVersionMap()
+	if err != nil {
+		return err
+	}
+
+	installedVersions, err := z.GetInstalledVersions()
+	if err != nil {
+		return err
+	}
+
+	options := make([]string, 0, len(zigVersions))
+	for key := range zigVersions {
+		options = append(options, "v"+key)
+	}
+
+	semver.Sort(options)
+	slices.Reverse(options)
+
+	versions := make([]RemoteVersionJSON, 0, len(options))
+	for _, version := range options {
+		stripped := version[1:]
+		if stripped == "master" {
+			continue
+		}
+
+		_, hasZLS := zlsVersions[stripped]
+		versions = append(versions, RemoteVersionJSON{
+			Version:   stripped,
+			Installed: slices.Contains(installedVersions, stripped),
+			ZLS:       hasZLS,
+		})
+	}
+
+	if master, ok := zigVersions["master"]; ok {
+		var remoteVersion string
+		if versionInfo, ok := master["version"].(string); ok {
+			remoteVersion = versionInfo
+		}
+
+		_, hasZLS := zlsVersions["master"]
+		masterVersion := RemoteVersionJSON{
+			Version:       "master",
+			Installed:     slices.Contains(installedVersions, "master"),
+			ZLS:           hasZLS,
+			RemoteVersion: remoteVersion,
+		}
+
+		if masterVersion.Installed {
+			targetZig := strings.TrimSpace(filepath.Join(z.baseDir, "master", "zig"))
+			cmd := exec.Command(targetZig, "version")
+			var zigVersion strings.Builder
+			cmd.Stdout = &zigVersion
+			if err := cmd.Run(); err != nil {
+				log.Warn(err)
+			} else {
+				localVersion := strings.TrimSpace(zigVersion.String())
+				masterVersion.LocalVersion = localVersion
+				masterVersion.Outdated = localVersion != remoteVersion
+			}
+		}
+
+		versions = append(versions, masterVersion)
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(versions)
 }

--- a/cli/meta/style.go
+++ b/cli/meta/style.go
@@ -1,0 +1,17 @@
+package meta
+
+import "github.com/charmbracelet/lipgloss"
+
+var TableHeaderStyle = lipgloss.NewStyle().Bold(true)
+
+var TableVersionHeaderStyle = TableHeaderStyle.Width(12)
+
+var TableInstalledHeaderStyle = TableHeaderStyle.Width(12)
+
+var TableInstalledVersionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#24ae32"))
+
+var TableRemoteVersionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#007fff"))
+
+var TableLocalVersionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f5c542"))
+
+var TableOutdatedVersionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f95d5d"))

--- a/main.go
+++ b/main.go
@@ -241,7 +241,17 @@ var zvmApp = &opts.Command{
 			Name:    "list-remote",
 			Usage:   "List all remote Zig versions",
 			Aliases: []string{"ls-remote"},
+			Flags: []opts.Flag{
+				&opts.BoolFlag{
+					Name:  "json",
+					Usage: "print remote Zig versions as JSON",
+				},
+			},
 			Action: func(ctx context.Context, cmd *opts.Command) error {
+				if cmd.Bool("json") {
+					return zvm.ListRemoteAvailableJSON()
+				}
+
 				return zvm.ListRemoteAvailable()
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tristanisham/clr"
 	"github.com/tristanisham/zvm/cli"
 	"github.com/tristanisham/zvm/cli/meta"
 	opts "github.com/urfave/cli/v3"
@@ -274,6 +275,7 @@ var zvmApp = &opts.Command{
 			Action: func(ctx context.Context, cmd *opts.Command) error {
 				log.Debug("Version Map", "url", zvm.Settings.VersionMapUrl, "cmd", "list/ls")
 				if cmd.Bool("all") {
+					log.Warnf("this flag is deprecated. Please use the %s command", clr.Yellow("ls-remote"))
 					return zvm.ListRemoteAvailable()
 				} else if cmd.Bool("vmu") {
 					if len(zvm.Settings.VersionMapUrl) == 0 {


### PR DESCRIPTION
Bring over the list-remote work from the feat/alias branch without the
alias functionality it was entangled with:

- Add 'zvm ls-remote --json' backed by ListRemoteAvailableJSON, which
  emits the remote version list (installed/ZLS status, and remote/local/
  outdated info for master) as JSON on stdout.
- Style the ls-remote table with lipgloss (bold headers, colored
  installed/remote/local/outdated labels) via new cli/meta/style.go,
  respecting the UseColor setting.

The alias column, Aliases JSON field, and aliasesByVersion helper were
left behind since cli/alias.go is not part of this port.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lz5DjBEaUxwL3NTz86JvVP