### PR TITLE
Port ls-remote improvements, colorized help, and fish completion fix from feat/alias

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -22,10 +23,14 @@ import (
 )
 
 var (
-	zvm                 cli.ZVM
+	zvm                      = *cli.Initialize()
 	printUpgradeNotice  bool = true
 	BuildUpgradeMessage      = "You should probably use your system package manager to update ZVM."
 )
+
+func init() {
+	opts.HelpPrinter = printZVMHelp
+}
 
 var zvmApp = &opts.Command{
 	Name:                  "zvm",
@@ -42,16 +47,27 @@ var zvmApp = &opts.Command{
 			"Example: source <(zvm completion bash)   # bash\n" +
 			"         zvm completion zsh > _zvm       # zsh, place on $fpath\n" +
 			"         zvm completion pwsh > zvm.ps1   # PowerShell, dot-source in profile"
+
+		for _, shellCmd := range cmd.Commands {
+			if shellCmd.Name != "fish" {
+				continue
+			}
+
+			shellCmd.Action = func(_ context.Context, command *opts.Command) error {
+				completion, err := command.Root().ToFishCompletion()
+				if err != nil {
+					return err
+				}
+				_, err = fmt.Fprint(command.Root().Writer, completion)
+				return err
+			}
+		}
 	},
 	// Route errors back through main() so they are reported via meta.CtaFatal
 	// instead of urfave/cli calling os.Exit itself. Without this, ExitCoder
 	// errors (e.g. an unknown completion shell) exit the process mid-Run,
 	// bypassing our error reporting and making Run untestable.
 	ExitErrHandler: func(ctx context.Context, cmd *opts.Command, err error) {},
-	Before: func(ctx context.Context, cmd *opts.Command) (context.Context, error) {
-		zvm = *cli.Initialize()
-		return nil, nil
-	},
 	// app-global flags
 	Flags: []opts.Flag{
 		&opts.StringFlag{
@@ -496,4 +512,29 @@ func main() {
 		}
 
 	}
+}
+
+func formatHelpSection(section string) string {
+	if !zvm.Settings.UseColor {
+		return section
+	}
+	return clr.Blue(section)
+}
+
+func printZVMHelp(w io.Writer, templ string, data any) {
+	styledTemplate := strings.NewReplacer(
+		"GLOBAL OPTIONS:", `{{section "GLOBAL OPTIONS:"}}`,
+		"NAME:", `{{section "NAME:"}}`,
+		"USAGE:", `{{section "USAGE:"}}`,
+		"VERSION:", `{{section "VERSION:"}}`,
+		"DESCRIPTION:", `{{section "DESCRIPTION:"}}`,
+		"COMMANDS:", `{{section "COMMANDS:"}}`,
+		"OPTIONS:", `{{section "OPTIONS:"}}`,
+		"CATEGORY:", `{{section "CATEGORY:"}}`,
+		"COPYRIGHT:", `{{section "COPYRIGHT:"}}`,
+	).Replace(templ)
+
+	opts.HelpPrinterCustom(w, styledTemplate, data, map[string]any{
+		"section": formatHelpSection,
+	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -101,6 +101,48 @@ func TestCompletionOutput(t *testing.T) {
 	}
 }
 
+func TestFishCompletionIsStatic(t *testing.T) {
+	t.Setenv("ZVM_PATH", t.TempDir())
+
+	var runErr error
+	got := captureStdout(t, func(w io.Writer) {
+		zvmApp.Writer = w
+		for _, c := range zvmApp.Commands {
+			if c.Name == "completion" {
+				c.Writer = w
+			}
+		}
+		runErr = zvmApp.Run(context.Background(), []string{"zvm", "completion", "fish"})
+	})
+	if runErr != nil {
+		t.Fatalf("unexpected error generating fish completion: %v", runErr)
+	}
+	if strings.Contains(got, "__zvm_perform_completion") {
+		t.Fatal("fish completion should use static definitions, not dynamic completion")
+	}
+	if !strings.Contains(got, "complete -c zvm") {
+		t.Fatal("fish completion is missing zvm completion definitions")
+	}
+	if !strings.Contains(got, "-l json") {
+		t.Fatal("fish completion is missing the list-remote --json flag")
+	}
+}
+
+func TestFormatHelpSectionHonorsColorSetting(t *testing.T) {
+	original := zvm.Settings.UseColor
+	t.Cleanup(func() { zvm.Settings.UseColor = original })
+
+	zvm.Settings.UseColor = false
+	if got := formatHelpSection("NAME:"); got != "NAME:" {
+		t.Errorf("plain help section = %q, want NAME:", got)
+	}
+
+	zvm.Settings.UseColor = true
+	if got := formatHelpSection("NAME:"); got == "NAME:" {
+		t.Error("colored help section did not contain ANSI styling")
+	}
+}
+
 func TestCompletionUnknownShell(t *testing.T) {
 	t.Setenv("ZVM_PATH", t.TempDir())
 


### PR DESCRIPTION
Cherry-picks the `list-remote`-related work from the `feat/alias` branch, leaving the alias feature itself behind so these improvements can ship independently.

## Changes

**`zvm ls-remote --json`**
- New `ListRemoteAvailableJSON` and `RemoteVersionJSON` struct that emit the remote version list as JSON on stdout — installed/ZLS status for each version, plus remote/local/outdated info for `master`.
- Wired up the `--json` flag on the `list-remote` / `ls-remote` command.

**Colorized `ls-remote` table**
- New `cli/meta/style.go` with lipgloss styles (bold headers; colored installed/remote/local/outdated labels), all gated on the `UseColor` setting.

**Deprecation warning**
- `zvm ls --all` now warns that the flag is deprecated and points to the `ls-remote` command.

**Colorized help menu**
- Custom `opts.HelpPrinter` colors help section headers (`NAME:`, `USAGE:`, `COMMANDS:`, …) in blue, honoring `UseColor`. ZVM initialization moves from the `Before` hook to a package-level var so settings are loaded before help can print.

**Fish completion fix**
- Overrides the generated `fish` subcommand to emit urfave/cli's static `ToFishCompletion` script instead of the dynamic completion shim.

## Notes
- The alias column / `Aliases` JSON field and `resolveVersionArg` were intentionally left out, since `cli/alias.go` is not part of this port.
- Tests added for the JSON path, static fish completion, and help-section coloring.

## Testing
- `go build .`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz5DjBEaUxwL3NTz86JvVP)_