### PR TITLE
Add support for installing specific Zig development builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,27 @@ zvm i --force master
 You can also enable the old behavior by setting the new `alwaysForceInstall`
 field to `true` in `~/.zvm/settings.json`.
 
+### Install a Specific Development Build
+
+Zig development builds can be installed by their full build identifier, such as
+`0.16.0-dev.1334+06d08daba`. ZVM downloads these builds directly from
+`ziglang.org/builds` because they are not listed in the release version map.
+
+Development builds do not have a version-map SHA-256 checksum. ZVM warns about
+this and asks for confirmation before continuing:
+
+```sh
+zvm i 0.16.0-dev.1334+06d08daba
+```
+
+For an explicit non-interactive install, pass `--skip-shasum` (or `-s`). This
+also skips SHA-256 verification for regular Zig and ZLS installations, so use
+it only when you accept that risk:
+
+```sh
+zvm i --skip-shasum 0.16.0-dev.1334+06d08daba
+```
+
 ### Customize HTTP Timeout
 You can pass a custom HTTP timeout (in seconds) for `zvm i` using the `--http.timeout` flag or by setting the `ZVM_HTTP_TIMEOUT` environment variable.
 

--- a/cli/dev_version_test.go
+++ b/cli/dev_version_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Tristan Isham. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package cli
+
+import "testing"
+
+func TestIsDevelopmentVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"0.16.0-dev.1334+06d08daba", true},
+		{"1.2.3-dev.0+abcdef", true},
+		{"0.16.0", false},
+		{"master", false},
+		{"v0.16.0-dev.1334+06d08daba", false},
+		{"0.16.0-dev.1334+06D08DABA", false},
+		{"0.16.0-dev+06d08daba", false},
+		{"0.16.0-dev.1334", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := IsDevelopmentVersion(tt.version); got != tt.want {
+				t.Errorf("IsDevelopmentVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDevelopmentVersionDownloadURL(t *testing.T) {
+	const version = "0.16.0-dev.1334+06d08daba"
+	tests := []struct {
+		name string
+		os   string
+		arch string
+		want string
+	}{
+		{
+			name: "linux tarball",
+			os:   "linux",
+			arch: "x86_64",
+			want: "https://ziglang.org/builds/zig-x86_64-linux-0.16.0-dev.1334+06d08daba.tar.xz",
+		},
+		{
+			name: "macos tarball",
+			os:   "macos",
+			arch: "aarch64",
+			want: "https://ziglang.org/builds/zig-aarch64-macos-0.16.0-dev.1334+06d08daba.tar.xz",
+		},
+		{
+			name: "windows zip",
+			os:   "windows",
+			arch: "x86_64",
+			want: "https://ziglang.org/builds/zig-x86_64-windows-0.16.0-dev.1334+06d08daba.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ZVM_TARGET_OS", tt.os)
+			t.Setenv("ZVM_TARGET_ARCH", tt.arch)
+
+			if got := developmentVersionDownloadURL(version); got != tt.want {
+				t.Errorf("developmentVersionDownloadURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequiresUnverifiedDownloadConfirmation(t *testing.T) {
+	tests := []struct {
+		name       string
+		shasum     string
+		skipShasum bool
+		want       bool
+	}{
+		{"missing shasum", "", false, true},
+		{"missing shasum explicitly skipped", "", true, false},
+		{"present shasum", "deadbeef", false, false},
+		{"present shasum explicitly skipped", "deadbeef", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requiresUnverifiedDownloadConfirmation(tt.shasum, tt.skipShasum); got != tt.want {
+				t.Errorf("requiresUnverifiedDownloadConfirmation(%q, %v) = %v, want %v", tt.shasum, tt.skipShasum, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/install.go
+++ b/cli/install.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -38,30 +39,72 @@ import (
 	"github.com/tristanisham/clr"
 )
 
-const httpDefaultTimeout = (60 * 3) * time.Second
+const (
+	httpDefaultTimeout = (60 * 3) * time.Second
+	zigBuildsBaseURL   = "https://ziglang.org/builds/"
+)
+
+var devVersionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+-dev\.\d+\+[0-9a-f]+$`)
+
+// IsDevelopmentVersion reports whether version names a specific Zig development build.
+func IsDevelopmentVersion(version string) bool {
+	return devVersionRegex.MatchString(version)
+}
+
+func zigArchiveExtension() string {
+	_, osName := zigStyleSysInfo()
+	if osName == "windows" {
+		return ".zip"
+	}
+	return ".tar.xz"
+}
+
+func developmentVersionDownloadURL(version string) string {
+	arch, osName := zigStyleSysInfo()
+	return fmt.Sprintf("%szig-%s-%s-%s%s", zigBuildsBaseURL, arch, osName, version, zigArchiveExtension())
+}
+
+func requiresUnverifiedDownloadConfirmation(shasum string, skipShasum bool) bool {
+	return shasum == "" && !skipShasum
+}
+
+func confirmUnverifiedDownload(artifact string) error {
+	fmt.Printf("%s has no SHA-256 checksum. Continue with this unverified download? [y/N]\n", artifact)
+	if !getConfirmation() {
+		return fmt.Errorf("installation of unverified %s cancelled", artifact)
+	}
+	return nil
+}
 
 // Install downloads and installs the specified Zig version.
 // It handles checking for existing installations, verifying checksums,
 // and extracting the downloaded bundle.
-func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
+func (z *ZVM) Install(version string, force bool, skipShasum bool, mirror bool) (string, error) {
 	if err := os.MkdirAll(z.baseDir, 0755); err != nil {
 		return version, err
 	}
 
-	rawVersionStructure, err := z.fetchVersionMap()
-	if err != nil {
-		return version, err
-	}
+	isDevelopmentVersion := IsDevelopmentVersion(version)
+	var rawVersionStructure zigVersionMap
+	var shasum string
+	var err error
 
-	// Resolve version shorthand (e.g. "0.12" -> "0.12.0", "stable" -> latest release)
-	availableVersions := make([]string, 0, len(rawVersionStructure))
-	for k := range rawVersionStructure {
-		availableVersions = append(availableVersions, k)
-	}
-	if resolved, err := resolveVersionShorthand(version, availableVersions); err == nil && resolved != version {
-		log.Debug("resolved version shorthand", "input", version, "resolved", resolved)
-		fmt.Printf("Resolved %q to %s\n", version, resolved)
-		version = resolved
+	if !isDevelopmentVersion {
+		rawVersionStructure, err = z.fetchVersionMap()
+		if err != nil {
+			return version, err
+		}
+
+		// Resolve version shorthand (e.g. "0.12" -> "0.12.0", "stable" -> latest release)
+		availableVersions := make([]string, 0, len(rawVersionStructure))
+		for k := range rawVersionStructure {
+			availableVersions = append(availableVersions, k)
+		}
+		if resolved, err := resolveVersionShorthand(version, availableVersions); err == nil && resolved != version {
+			log.Debug("resolved version shorthand", "input", version, "resolved", resolved)
+			fmt.Printf("Resolved %q to %s\n", version, resolved)
+			version = resolved
+		}
 	}
 
 	if !force {
@@ -98,11 +141,27 @@ func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
 		}
 	}
 
-	tarPath, err := getTarPath(version, &rawVersionStructure)
-	if err != nil {
-		if errors.Is(err, ErrUnsupportedVersion) {
-			return version, fmt.Errorf("%s: %q", err, version)
-		} else {
+	var tarPath string
+	if isDevelopmentVersion {
+		tarPath = developmentVersionDownloadURL(version)
+		log.Debug("development version detected", "version", version, "url", tarPath)
+	} else {
+		tarPath, err = getTarPath(version, &rawVersionStructure)
+		if err != nil {
+			if errors.Is(err, ErrUnsupportedVersion) {
+				return version, fmt.Errorf("%s: %q", err, version)
+			}
+			return version, err
+		}
+
+		shasum, err = getVersionShasum(version, &rawVersionStructure)
+		if err != nil {
+			return version, err
+		}
+	}
+
+	if requiresUnverifiedDownloadConfirmation(shasum, skipShasum) {
+		if err := confirmUnverifiedDownload(fmt.Sprintf("Zig version %s", version)); err != nil {
 			return version, err
 		}
 	}
@@ -113,17 +172,20 @@ func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
 	var minisig minisign.Signature
 	var verifyMinisig bool
 
-	// Only the official version map serves builds signed with the pinned
-	// minisign key; custom version maps distribute their own builds, so
-	// signature verification can't apply to them.
-	isOfficialVMUSet := z.Settings.VersionMapUrl == DefaultSettings.VersionMapUrl
-	mirror = mirror && z.Settings.UseMirrorList() && isOfficialVMUSet
+	// Official Zig sources serve builds signed with the pinned minisign key;
+	// custom version maps distribute their own builds, so signature verification
+	// cannot apply to them.
+	isOfficialSource := isDevelopmentVersion || z.Settings.VersionMapUrl == DefaultSettings.VersionMapUrl
+	mirror = !isDevelopmentVersion && mirror && z.Settings.UseMirrorList() && isOfficialSource
 	if mirror {
 		tarResp, minisig, err = attemptMirrorDownload(z.Settings.MirrorListUrl, tarPath)
 		verifyMinisig = err == nil
 	} else {
 		tarResp, err = attemptDownload(tarPath, nil)
-		if err == nil && isOfficialVMUSet {
+		if isDevelopmentVersion && err != nil && strings.Contains(err.Error(), "404") {
+			fmt.Println("This version of Zig may be no longer available.")
+		}
+		if err == nil && isOfficialSource {
 			// ziglang.org publishes a .minisig for every build, so a missing
 			// signature is a failed download, not a reason to skip verification.
 			minisig, err = attemptMinisigDownload(tarPath, nil)
@@ -174,15 +236,10 @@ func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
 		return version, err
 	}
 
-	var shasum string
-
-	shasum, err = getVersionShasum(version, &rawVersionStructure)
-	if err != nil {
-		return version, err
-	}
-
-	fmt.Println("Checking shasum...")
-	if len(shasum) > 0 {
+	if skipShasum {
+		fmt.Println("Skipping shasum check (user requested)")
+	} else if len(shasum) > 0 {
+		fmt.Println("Checking shasum...")
 		ourHexHash := hex.EncodeToString(hash.Sum(nil))
 		log.Debug("shasum check:", "theirs", shasum, "ours", ourHexHash)
 		if ourHexHash != shasum {
@@ -193,8 +250,6 @@ func (z *ZVM) Install(version string, force bool, mirror bool) (string, error) {
 			return version, fmt.Errorf("shasum for %v does not match expected value", version)
 		}
 		fmt.Println("Shasums match! 🎉")
-	} else {
-		log.Warnf("No shasum provided by host")
 	}
 
 	if verifyMinisig {
@@ -303,7 +358,7 @@ func attemptMirrorDownload(mirrorListURL string, tarURL string) (*http.Response,
 	mirrors = mirrors[:len(mirrors)-1]
 	rand.Shuffle(len(mirrors), func(i, j int) { mirrors[i], mirrors[j] = mirrors[j], mirrors[i] })
 	// Default as fallback
-	mirrors = append(mirrors, "https://ziglang.org/builds/")
+	mirrors = append(mirrors, zigBuildsBaseURL)
 
 	for i, mirror := range mirrors {
 		mirrorTarURL, err := url.JoinPath(mirror, tarName)
@@ -472,7 +527,7 @@ func (z *ZVM) SelectZlsVersion(version string, compatMode string) (string, strin
 }
 
 // InstallZls downloads and installs the Zig Language Server (ZLS) for the specified Zig version.
-func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool) error {
+func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool, skipShasum bool) error {
 	fmt.Println("Determining installed Zig version...")
 
 	// make sure dir exists
@@ -504,6 +559,11 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 		}
 	}
 	log.Debug("selected zls version", "zigVersion", zigVersion, "zlsVersion", zlsVersion)
+	if requiresUnverifiedDownloadConfirmation(shasum, skipShasum) {
+		if err := confirmUnverifiedDownload(fmt.Sprintf("ZLS version %s", zlsVersion)); err != nil {
+			return err
+		}
+	}
 
 	_, osType := zigStyleSysInfo()
 	filename := "zls"
@@ -573,8 +633,10 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 		return err
 	}
 
-	fmt.Println("Checking ZLS shasum...")
-	if len(shasum) > 0 {
+	if skipShasum {
+		fmt.Println("Skipping ZLS shasum check (user requested)")
+	} else if len(shasum) > 0 {
+		fmt.Println("Checking ZLS shasum...")
 		ourHexHash := hex.EncodeToString(hash.Sum(nil))
 		log.Debug("shasum check:", "theirs", shasum, "ours", ourHexHash)
 		if ourHexHash != shasum {
@@ -585,8 +647,6 @@ func (z *ZVM) InstallZls(requestedVersion string, compatMode string, force bool)
 			return fmt.Errorf("shasum for zls-%v does not match expected value", zlsVersion)
 		}
 		fmt.Println("Shasums for ZLS match! 🎉")
-	} else {
-		log.Warnf("No ZLS shasum provided by host")
 	}
 
 	fmt.Println("Extracting ZLS bundle...")

--- a/cli/run.go
+++ b/cli/run.go
@@ -37,34 +37,35 @@ func (z *ZVM) Run(version string, cmd []string) error {
 	if slices.Contains(installedVersions, version) {
 		return z.runZig(version, cmd)
 	} else {
-		rawVersionStructure, err := z.fetchVersionMap()
-		if err != nil {
-			return err
-		}
+		if !IsDevelopmentVersion(version) {
+			rawVersionStructure, err := z.fetchVersionMap()
+			if err != nil {
+				return err
+			}
 
-		// Also resolve against remote versions if not found locally
-		remoteVersions := make([]string, 0, len(rawVersionStructure))
-		for k := range rawVersionStructure {
-			remoteVersions = append(remoteVersions, k)
-		}
-		if resolved, resolveErr := resolveVersionShorthand(version, remoteVersions); resolveErr == nil && resolved != version {
-			log.Debug("resolved version shorthand (remote)", "input", version, "resolved", resolved)
-			version = resolved
-		}
+			// Also resolve against remote versions if not found locally
+			remoteVersions := make([]string, 0, len(rawVersionStructure))
+			for k := range rawVersionStructure {
+				remoteVersions = append(remoteVersions, k)
+			}
+			if resolved, resolveErr := resolveVersionShorthand(version, remoteVersions); resolveErr == nil && resolved != version {
+				log.Debug("resolved version shorthand (remote)", "input", version, "resolved", resolved)
+				version = resolved
+			}
 
-		_, err = getTarPath(version, &rawVersionStructure)
-		if err != nil {
-			if errors.Is(err, ErrUnsupportedVersion) {
-				return fmt.Errorf("%w: %q", err, version)
-			} else {
+			_, err = getTarPath(version, &rawVersionStructure)
+			if err != nil {
+				if errors.Is(err, ErrUnsupportedVersion) {
+					return fmt.Errorf("%w: %q", err, version)
+				}
 				return err
 			}
 		}
 
-		fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", version)
+		fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/N]\n", version)
 
 		if getConfirmation() {
-			if version, err = z.Install(version, false, true); err != nil {
+			if version, err = z.Install(version, false, false, true); err != nil {
 				return err
 			}
 			return z.runZig(version, cmd)

--- a/cli/use.go
+++ b/cli/use.go
@@ -34,9 +34,9 @@ func (z *ZVM) Use(ver string) (string, error) {
 	if err := z.getVersion(ver); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 
-			fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/n]\n", ver)
+			fmt.Printf("It looks like %s isn't installed. Would you like to install it? [y/N]\n", ver)
 			if getConfirmation() {
-				if ver, err = z.Install(ver, false, true); err != nil {
+				if ver, err = z.Install(ver, false, false, true); err != nil {
 					return ver, err
 				}
 			} else {

--- a/main.go
+++ b/main.go
@@ -107,6 +107,11 @@ var zvmApp = &opts.Command{
 					Usage:   "force installation even if the version is already installed",
 				},
 				&opts.BoolFlag{
+					Name:    "skip-shasum",
+					Aliases: []string{"s"},
+					Usage:   "skip SHA-256 verification and the unverified-download confirmation",
+				},
+				&opts.BoolFlag{
 					Name:  "full",
 					Usage: "use the 'full' zls compatibility mode",
 				},
@@ -168,14 +173,14 @@ var zvmApp = &opts.Command{
 				}
 
 				// Install Zig
-				resolvedVersion, err := zvm.Install(req.Package, force, !cmd.Bool("nomirror"))
+				resolvedVersion, err := zvm.Install(req.Package, force, cmd.Bool("skip-shasum"), !cmd.Bool("nomirror"))
 				if err != nil {
 					return err
 				}
 
 				// Install ZLS (if requested)
 				if cmd.Bool("zls") {
-					if err := zvm.InstallZls(resolvedVersion, zlsCompat, force); err != nil {
+					if err := zvm.InstallZls(resolvedVersion, zlsCompat, force, cmd.Bool("skip-shasum")); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
Reimplements the feature from PR #141 in ZVM's house style, following
the design discussed there:

- Versions matching the dev-build pattern (e.g. 0.16.0-dev.1334+06d08daba)
  bypass the version map and download directly from ziglang.org/builds,
  with the archive extension chosen per platform (.zip on Windows).
- Minisign verification is retained for dev builds — ziglang.org signs
  every build, so only the version-map SHA-256 is unavailable.
- Instead of overloading --force, any install without a known SHA-256
  checksum warns and asks for confirmation before downloading.
- A new --skip-shasum (-s) flag on install skips SHA-256 verification
  and the unverified-download confirmation for non-interactive use;
  it applies to Zig and ZLS installs alike.
- zvm run/use prompt-installs pass through to the same flow, and run
  no longer consults the version map for dev builds.
- Table-driven tests cover dev-version detection, download URL
  construction, and the confirmation predicate.

Closes #141

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lz5DjBEaUxwL3NTz86JvVP