### PR TITLE
Add Winget MSI packaging workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,199 @@
+name: Winget
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to embed in the MSI, for example 0.8.28
+        required: true
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-msi:
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - go-architecture: amd64
+            msi-architecture: x64
+            msi-name: zvm-windows-amd64
+          - go-architecture: arm64
+            msi-architecture: arm64
+            msi-name: zvm-windows-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Resolve package version
+        id: version
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "release") {
+            $version = "${{ github.event.release.tag_name }}"
+          } else {
+            $version = "${{ inputs.version }}"
+          }
+
+          $version = $version.TrimStart("v")
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+            throw "MSI versions must contain three numeric parts: $version"
+          }
+
+          "value=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Build ZVM
+        shell: pwsh
+        run: |
+          $env:CGO_ENABLED = "0"
+          $env:GOOS = "windows"
+          $env:GOARCH = "${{ matrix.go-architecture }}"
+          New-Item -ItemType Directory -Force build | Out-Null
+          go build -tags noAutoUpgrades -trimpath -ldflags "-s -w" -o build/zvm.exe .
+
+      - name: Build MSI
+        shell: pwsh
+        run: |
+          $sourceExe = (Resolve-Path build/zvm.exe).Path
+          dotnet build installer/windows/ZVM.wixproj `
+            --configuration Release `
+            --output build/msi `
+            -p:ProductVersion=${{ steps.version.outputs.value }} `
+            -p:SourceExe="$sourceExe" `
+            -p:MsiArchitecture=${{ matrix.msi-architecture }} `
+            -p:MsiName=${{ matrix.msi-name }}
+
+      - name: Test x64 MSI install and uninstall
+        if: matrix.go-architecture == 'amd64'
+        shell: pwsh
+        run: |
+          $msi = (Resolve-Path "build/msi/${{ matrix.msi-name }}.msi").Path
+          $install = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            "/i", "`"$msi`"", "/qn", "/norestart", "/l*v", "install.log"
+          )
+          if ($install.ExitCode -ne 0) {
+            Get-Content install.log
+            throw "MSI installation failed with exit code $($install.ExitCode)"
+          }
+
+          $installedExe = Join-Path $HOME ".zvm/self/zvm.exe"
+          if (-not (Test-Path $installedExe)) {
+            throw "The MSI did not install zvm.exe at $installedExe"
+          }
+          & $installedExe --version
+
+          $environment = Get-ItemProperty "HKCU:\Environment"
+          $expectedInstall = (Join-Path $HOME ".zvm\self").TrimEnd("\")
+          $actualInstall = $environment.ZVM_INSTALL.TrimEnd("\")
+          if ($actualInstall -ine $expectedInstall) {
+            throw "Unexpected ZVM_INSTALL value: $($environment.ZVM_INSTALL)"
+          }
+          $pathEntries = $environment.Path -split ";" | ForEach-Object { $_.TrimEnd("\") }
+          if ($pathEntries -inotcontains $expectedInstall) {
+            throw "ZVM_INSTALL was not added to the user PATH"
+          }
+          $expectedBin = (Join-Path $HOME ".zvm\bin").TrimEnd("\")
+          if ($pathEntries -inotcontains $expectedBin) {
+            throw "The ZVM bin directory was not added to the user PATH"
+          }
+
+          $uninstall = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            "/x", "`"$msi`"", "/qn", "/norestart", "/l*v", "uninstall.log"
+          )
+          if ($uninstall.ExitCode -ne 0) {
+            Get-Content uninstall.log
+            throw "MSI uninstallation failed with exit code $($uninstall.ExitCode)"
+          }
+          if (Test-Path $installedExe) {
+            throw "MSI uninstallation did not remove zvm.exe"
+          }
+
+          $environment = Get-ItemProperty "HKCU:\Environment"
+          if ($null -ne $environment.ZVM_INSTALL) {
+            throw "MSI uninstallation did not remove ZVM_INSTALL"
+          }
+          $pathEntries = $environment.Path -split ";" | ForEach-Object { $_.TrimEnd("\") }
+          if ($pathEntries -icontains $expectedInstall -or $pathEntries -icontains $expectedBin) {
+            throw "MSI uninstallation did not remove ZVM's PATH entries"
+          }
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.msi-name }}
+          path: build/msi/${{ matrix.msi-name }}.msi
+          if-no-files-found: error
+
+      - name: Attach MSI to release
+        if: github.event_name == 'release'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "build/msi/${{ matrix.msi-name }}.msi" --clobber
+
+  submit-winget:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: build-msi
+    runs-on: windows-latest
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+
+    steps:
+      - name: Set up .NET 6
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Download MSI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: zvm-windows-*
+          path: build
+          merge-multiple: true
+
+      - name: Submit Winget update
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
+            Write-Warning "WINGET_CREATE_GITHUB_TOKEN is not configured; skipping Winget submission."
+            exit 0
+          }
+
+          $packagePath = "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/t/TristanIsham/ZVM"
+          try {
+            Invoke-RestMethod -Uri $packagePath -Headers @{ "User-Agent" = "zvm-winget-workflow" } | Out-Null
+          } catch {
+            if ($_.Exception.Response.StatusCode.value__ -eq 404) {
+              Write-Warning "TristanIsham.ZVM has not been accepted into winget-pkgs yet. Complete the one-time initial submission documented in installer/windows/README.md."
+              exit 0
+            }
+            throw
+          }
+
+          $tag = "${{ github.event.release.tag_name }}"
+          $version = $tag.TrimStart("v")
+          $releaseBase = "https://github.com/tristanisham/zvm/releases/download/$tag"
+          $x64Url = "$releaseBase/zvm-windows-amd64.msi"
+          $arm64Url = "$releaseBase/zvm-windows-arm64.msi"
+
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update TristanIsham.ZVM `
+            --version $version `
+            --urls $x64Url $arm64Url `
+            --submit

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ zig-out/
 cmake-build/
 build/
 dist/
+installer/windows/bin/
+installer/windows/obj/
 demo/
 zvm
 zvm.exe

--- a/installer/windows/Package.wxs
+++ b/installer/windows/Package.wxs
@@ -1,0 +1,53 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+    Name="ZVM"
+    Manufacturer="Tristan Isham"
+    Version="$(var.ProductVersion)"
+    UpgradeCode="34792705-2eed-480c-ac6b-52b8fbdbbac9"
+    Scope="perUser">
+
+    <SummaryInformation Description="Zig Version Manager" />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of ZVM is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <Feature Id="Main" Title="ZVM" Level="1">
+      <ComponentRef Id="ZvmExecutable" />
+    </Feature>
+
+    <SetDirectory Id="INSTALLFOLDER" Value="[%USERPROFILE]\.zvm\self" />
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="INSTALLFOLDER" />
+    </StandardDirectory>
+  </Fragment>
+
+  <Fragment>
+    <DirectoryRef Id="INSTALLFOLDER">
+      <Component Id="ZvmExecutable" Guid="*">
+        <File Id="ZvmExe" Source="$(var.SourceExe)" Name="zvm.exe" KeyPath="yes" />
+        <Environment
+          Id="ZvmInstallEnvironment"
+          Name="ZVM_INSTALL"
+          Value="[INSTALLFOLDER]"
+          Action="set"
+          System="no" />
+        <Environment
+          Id="ZvmSelfPath"
+          Name="PATH"
+          Value="[INSTALLFOLDER]"
+          Action="set"
+          Part="last"
+          System="no" />
+        <Environment
+          Id="ZvmBinPath"
+          Name="PATH"
+          Value="[%USERPROFILE]\.zvm\bin"
+          Action="set"
+          Part="last"
+          System="no" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -1,0 +1,38 @@
+# Windows MSI and Winget
+
+The `winget.yml` workflow builds per-user x64 and ARM64 MSI packages on
+`windows-latest`. Each package installs `zvm.exe` to
+`%USERPROFILE%\.zvm\self`, sets `ZVM_INSTALL`, and adds both
+`%USERPROFILE%\.zvm\self` and `%USERPROFILE%\.zvm\bin` to the user's `PATH`.
+The packaged binary is built with the `noAutoUpgrades` tag so updates remain
+managed by Winget.
+
+The installer project intentionally pins WiX 5.0.2. WiX 6 and later binary
+releases are distributed under Open Source Maintenance Fee terms.
+
+Publishing a non-prerelease GitHub release attaches both MSI files to the
+release. Once `TristanIsham.ZVM` exists in `microsoft/winget-pkgs`, the workflow
+also uses WingetCreate to open the version-update pull request.
+
+## Repository setup
+
+Add a repository secret named `WINGET_CREATE_GITHUB_TOKEN`. It must contain a
+GitHub personal access token (classic) with the `repo` scope, as required by
+WingetCreate's CI documentation. If the secret is absent, MSI creation and
+release uploads still run, but Winget submission is skipped.
+
+## First Winget submission
+
+WingetCreate's `new` command is interactive, so the first package submission is
+a one-time maintainer step after publishing a release:
+
+```powershell
+Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+.\wingetcreate.exe new `
+  https://github.com/tristanisham/zvm/releases/download/v0.8.28/zvm-windows-amd64.msi `
+  https://github.com/tristanisham/zvm/releases/download/v0.8.28/zvm-windows-arm64.msi
+```
+
+Set the package identifier to `TristanIsham.ZVM`, review the generated
+manifests, and submit the pull request. After Microsoft accepts it, future
+non-prerelease releases are submitted automatically by the workflow.

--- a/installer/windows/ZVM.wixproj
+++ b/installer/windows/ZVM.wixproj
@@ -1,0 +1,15 @@
+<Project Sdk="WixToolset.Sdk/5.0.2">
+  <PropertyGroup>
+    <OutputType>Package</OutputType>
+    <OutputName>$(MsiName)</OutputName>
+    <InstallerPlatform>$(MsiArchitecture)</InstallerPlatform>
+    <DefineConstants>ProductVersion=$(ProductVersion);SourceExe=$(SourceExe)</DefineConstants>
+  </PropertyGroup>
+
+  <Target Name="ValidateBuildProperties" BeforeTargets="BeforeBuild">
+    <Error Condition="'$(ProductVersion)' == ''" Text="ProductVersion is required." />
+    <Error Condition="'$(SourceExe)' == ''" Text="SourceExe is required." />
+    <Error Condition="'$(MsiArchitecture)' == ''" Text="MsiArchitecture is required." />
+    <Error Condition="'$(MsiName)' == ''" Text="MsiName is required." />
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary

- add WiX 5.0.2 authoring for per-user x64 and ARM64 ZVM MSI packages
- build and smoke-test the MSIs on `windows-latest` with `noAutoUpgrades`
- attach MSIs to stable GitHub releases and submit subsequent versions with WingetCreate
- document the one-time initial `TristanIsham.ZVM` submission and required repository secret

The MSI preserves ZVM's existing Windows layout under `%USERPROFILE%\\.zvm\\self`, manages `ZVM_INSTALL` and the two user PATH entries, and removes those entries during uninstall.

## Validation

- `go test ./...`
- Windows amd64 and arm64 cross-builds with `-tags noAutoUpgrades`
- `actionlint .github/workflows/winget.yml`
- `git diff --check`

The final MSI binding and install/uninstall smoke test require `windows-latest`; WiX cannot complete the Windows Installer binding stage on this Linux host.
