### PR TITLE
Fix WiX ICE validation failures in the MSI build

### DIFF
--- a/installer/windows/Package.wxs
+++ b/installer/windows/Package.wxs
@@ -25,8 +25,18 @@
 
   <Fragment>
     <DirectoryRef Id="INSTALLFOLDER">
-      <Component Id="ZvmExecutable" Guid="*">
-        <File Id="ZvmExe" Source="$(var.SourceExe)" Name="zvm.exe" KeyPath="yes" />
+      <Component Id="ZvmExecutable" Guid="6c8b1f0e-9a5d-4c2b-8f7a-1d3e5b9c04a7">
+        <!-- ICE38: a component installing into the user profile must key off HKCU. -->
+        <RegistryValue
+          Root="HKCU"
+          Key="Software\TristanIsham\ZVM"
+          Name="InstallFolder"
+          Type="string"
+          Value="[INSTALLFOLDER]"
+          KeyPath="yes" />
+        <File Id="ZvmExe" Source="$(var.SourceExe)" Name="zvm.exe" />
+        <!-- ICE64: user-profile directories must be removed on uninstall. -->
+        <RemoveFolder Id="RemoveZvmSelfFolder" Directory="INSTALLFOLDER" On="uninstall" />
         <Environment
           Id="ZvmInstallEnvironment"
           Name="ZVM_INSTALL"


### PR DESCRIPTION
The v0.8.29 release run of the Winget workflow failed both MSI builds during ICE validation:

  ICE38: Component ZvmExecutable installs to user profile. It must use a
         registry key under HKCU as its KeyPath, not a file.
  ICE64: The directory INSTALLFOLDER is in the user profile but is not
         listed in the RemoveFile table.

Key the component off an HKCU registry value instead of zvm.exe, and add a RemoveFolder so the per-user install directory is cleaned up on uninstall. The component now needs an explicit GUID because auto-GUIDs require a file keypath.